### PR TITLE
Highcontrast colors for the installer

### DIFF
--- a/yast/cyan-black.qss
+++ b/yast/cyan-black.qss
@@ -1,3 +1,5 @@
+@import url("installation.qss");
+
 /* Richtext: installation_richtext.css */
 QMainWindow { background: black; }
 QFileDialog { background: black; }
@@ -6,33 +8,19 @@ QDialog { background: black; }
 YQWizard { background: black; }
 
 #LogoHBox {
-  background-color: #6da741;
   background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
     stop: 0 cyan, stop: 0.5 #00a489, stop: 1 #6da741);
   border-bottom: 1px solid cyan;
 }
-#DialogLogo {
-  background-image: url(logo.png);
-  min-width: 88px;
-  min-height: 58px;
-  margin-left: 10px;
-
-  margin-right: 10px;
-
-  background-color: none;
-}
 
 #work_area {
-  padding: 1em;
   background-color: black;
 }
 
 YQLogView,
 QTextEdit,
 YQRichText > YQTextBrowser {
-  qproperty-frameShape: NoShape;
   color: cyan;
-  border-radius: 0px;
   border: 1px solid cyan;
   background-color: black;
   selection-background-color: cyan;
@@ -52,11 +40,7 @@ QHeaderView::section {
   background-color: black;
   color: cyan;
   border: 1px outset cyan;
-  border-radius: 0px;
-  padding: 6px 8px;
 }
-QHeaderView::down-arrow { image: url(arr_down.png); padding-top: 2px; }
-QHeaderView::up-arrow { image: url(arr_up.png); padding-top: 2px; }
 
 QAbstractScrollArea { background-color: black; }
 
@@ -64,10 +48,8 @@ QTreeView, QTreeWidget {
   color: cyan;
   background-color: black;
   border: 1px solid cyan;
-  alternate-background-color: #2a2a2a;
   selection-background-color: cyan;
   selection-color: black;
-  border-radius: 0px;
 }
 
 QTableWidget,
@@ -77,7 +59,6 @@ QTableView {
   border: 1px solid cyan;
   selection-background-color: cyan;
   selection-color: black;
-  border-radius: 0px;
 }
 YQTree, YQTable {
   color: cyan;
@@ -92,7 +73,6 @@ YQPakageSelector {
   border: 1px inset cyan;
   selection-background-color: cyan;
   selection-color: black;
-  border-radius: 0px; 
 }
 
 YQGenericDetailsView,
@@ -109,22 +89,15 @@ QListWidget {
 }
 
 #DialogHeadingLeft {
-  font-family: Raleway, Sans-serif;
-  font: 24pt;
   color: cyan;
-  margin-top: 100%;
-  margin-right: 20px;
-  qproperty-alignment:AlignRight;
 }
 #DialogHeadingTop {
-  font-family: Raleway, Sans-serif;
-  font: 24pt;
   color: cyan;
 }
 
 QSpinBox,
 QDateEdit,
-QTimeEdit { color: cyan; background-color: #262626; padding: 3px 8px; min-height:24px; selection-background-color: cyan; selection-color: black; }
+QTimeEdit { color: cyan; background-color: #262626; selection-background-color: cyan; selection-color: black; }
 
 QDateEdit::disabled, QTimeEdit::disabled{ color: gray; background-color: black; }
 
@@ -134,9 +107,6 @@ YQWidgetCaption::disabled  { color: gray; background-color: black; }
 QLineEdit {
   color: cyan;
   background-color: #262626;
-  border-radius: 0px;
-  padding: 3px 8px;
-  min-height: 24px;
   selection-background-color: cyan;
   selection-color: black;
   border: 1px solid cyan;
@@ -148,41 +118,9 @@ QLineEdit::focus {
 
 QCheckBox { min-height: 20px; color: cyan; }
 
-QCheckBox::disabled { color: gray; }
-
-YQCheckBoxFrame::indicator:checked,
-QCheckBox::indicator:checked:enabled {
-  image: url(inst_checkbox-on.png);
-}
-YQCheckBoxFrame::indicator:unchecked,
-QCheckBox::indicator:unchecked:enabled {
-  image: url(inst_checkbox-off.png);
-}
-
-QCheckBox::indicator:checked:disabled {
-  image: url(inst_checkbox-on-disabled.png);
-}
-YQCheckBoxFrame::indicator:unchecked:disabled,
-QCheckBox::indicator:unchecked {
-  image: url(inst_checkbox-off-disabled.png);
-}
-
 QRadioButton {color: cyan }
 
 QRadioButton::disabled { color: gray; background-color: black; }
-
-QRadioButton::indicator:unchecked {
-   image: url(inst_radio-button-unchecked.png);
-}
-QRadioButton::indicator:checked {
-   image: url(inst_radio-button-checked.png);
-}
-QRadioButton::indicator:unchecked:disabled {
-   image: url(inst_radio-button-unchecked-disabled.png);
-}
-QRadioButton::indicator:checked:disabled {
-   image: url(inst_radio-button-checked-disabled.png);
-}
 
 YQMultiLineEdit QTextEdit { color: cyan; }
 
@@ -191,64 +129,36 @@ QMessageBox { background-color: black; }
 .conflict QWidget { color: cyan; }
 
 YQMultiProgressMeter {
-  background-color: transparent;
   border: 1px solid cyan;
-  border-radius: 0px;
 }
 
-YQProgressBar > YQWidgetCaption { margin-top: 20px; }
-
-/* Tab bars*/
-QTabWidget::pane {
-  border: none;
-}
-
-QTabBar
-{
-  qproperty-drawBase: 0;
-  /* Duplicate QTabBar::tab property.
-     Without this property, the tab space is calculated narrower and bold font
-     display messes up. See bnc#888589, bsc#948311 and QTBUG#8209 */
-  font-weight: bold;
-}
 QTabBar::tab {
   color: cyan;
   background: black;
   border: 1px solid cyan;
-  font-weight: bold;
-  padding: 4px 8px;
-  min-width: 180px;
-  min-height: 24px;
 }
 
 QTabBar::tab:selected {
   color: cyan;
   background: black;
   border: 1px solid cyan;
-  border-bottom: none;
 }
 
 QTabBar::tab:!selected:hover {
   color: cyan;
-  background: #35b9ab;
   border: 1px solid cyan;
 }
 
 QTabBar::tear {
   background: black;
   border: 1px solid cyan;
-  border-radius: 0px;
 }
 
 
 QComboBox {
   border: 1px solid cyan;
-  border-radius: 0px;
   color: cyan;
-  min-height: 24px;
-  padding: 3px 12px;
   background: black;
-  font-weight: bold;
   selection-background-color: cyan;
   selection-color: black;
 }
@@ -266,20 +176,6 @@ QComboBox:focus {
 QComboBox:!editable:on, QComboBox::drop-down:editable:on {
   color: gray;
 }
-QComboBox::drop-down { /* arrow part of the widget */
-  subcontrol-origin: padding;
-  subcontrol-position: top right;
-  width: 24px;
-  border: none;
-}
-QComboBox::down-arrow {
-  image: url(arr_down.png);
-}
-QComboBox::down-arrow:on { /* shift the arrow when popup is open */
-  image: url(arr_up.png);
-  top: 0px;
-  left: 0px;
-}
 QComboBox QAbstractItemView,
 QMenuBar {
   background-color: black;
@@ -289,11 +185,6 @@ QMenuBar {
 
 QMenuBar::item {
   color: cyan;
-  spacing: 3px; /* spacing between menu bar items */
-  padding: 6px 0px ;
-  background: transparent;
-  border-radius: 0px;
-  margin: 6px 0px;
 }
 
 QMenuBar::item:selected { /* when selected using mouse or keyboard */
@@ -312,27 +203,15 @@ QMenu {
   selection-background-color: cyan;
   selection-color: black;
 }
-QGroupBox {
-  border: 0px;
-  margin-top: 2.5ex;
-  margin-left: 10px;
-}
+
 QGroupBox::title {
-  subcontrol-origin: margin;
-  subcontrol-position: left top;
-  font-weight: bold;
   color: cyan;
 }
 
 QPushButton {
   border: 1px solid cyan;
-  border-radius: 0px;
   background-color: black;
-  min-height: 24px;
-  min-width: 40px;
-  padding: 3px 12px;
   color: cyan;
-  font-weight: bold;
 }
 QPushButton:focus, QPushButton:focus:default {
   border: 1px solid cyan;
@@ -360,154 +239,42 @@ QPushButton:default {
   color: black;
   background-color: cyan;
 }
-/* odd dropdown button widget */
-QPushButton::menu-indicator,
-QPushButton::menu-indicator:pressed,
-QPushButton::menu-indicator:open {
-  subcontrol-origin: margin;
-  left: -7px;
-  subcontrol-position: right;
-  image: url(arr_down.png);
-}
 QPushButton:open { /* when the button has its menu open */
   color: cyan;
   background: black;
   border: 1px solid cyan;
 }
 
-/* Tab Buttons               */
-
 QToolButton {
   border: 1px solid cyan;
   background-color: black;
 }
-QToolButton::left-arrow {
-  image: url(arr_left.png);
-}
-QToolButton::right-arrow {
-  image: url(arr_right.png);
-}
-QToolButton::up-arrow {
-  image: url(arr_lup.png);
-}
-QToolButton::down-arrow {
-  image: url(arr_down.png);
-}
-
-
 
 QProgressBar {
   border: 1px solid cyan;
-  border-radius: 0px;
-  text-align: center;
   color: black;
   background-color: cyan;
 }
-QProgressBar::chunk {
-  background-color:  gray;
-  border: 1px solid gray;
-  border-radius: 2px;
-}
-
-/* Vertical Scrollbars        */
-
 QScrollBar:vertical {
-  width: 14px;
-  margin: 0px 0px 0px 0px;
   background: cyan;
-  border: none;
 }
 QScrollBar::handle:vertical {
-  min-height: 16px;
   background-color: black;
-  border-radius: 0px;
-}
-QScrollBar::add-line:vertical {
-  subcontrol-position: bottom;
-  subcontrol-origin: margin;
-  border: none;
-  height: 0px;
-  width: 0px;
-}
-QScrollBar::sub-line:vertical {
-  subcontrol-position: top;
-  subcontrol-origin: margin;
-  border: none;
-  height: 0px;
-  width: 0px;
-}
-QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical {
-  width: 0px;
-  height: 0px;
-}
-QScrollBar::up-arrow:vertical { background-image: none; }
-QScrollBar::down-arrow:vertical {  background-image: none; }
-
-/* Horizontal Scrollbars      */
-
-QScrollBar:horizontal {
-  height: 14px;
-  margin: 0px 0px 0px 0px;
-  background-color: #f1f0f2;
-  border: none;
 }
 QScrollBar::handle:horizontal {
-  min-width: 16px;
   background-color: cyan;
-  border-radius: 0px;
 }
-QScrollBar::add-line:horizontal {
-  border: none;
-  background-color: transparent;
-  height: 0px;
-  width: 0px;
-  subcontrol-position: right;
-  subcontrol-origin: margin;
-}
-QScrollBar::sub-line:horizontal {
-  border: none;
-  background-color: transparent;
-  height: 0px;
-  width: 0px;
-  subcontrol-position: left;
-  subcontrol-origin: margin;
-}
-QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal {
-  width: 0px;
-}
-QScrollBar::right-arrow:horizontal { background-image: none; }
-QScrollBar::left-arrow:horizontal { background-image: none; }
 
 BusyBar {
- qproperty-frameShape: NoShape;
- border-width: 3px;
  border: 1px solid cyan;
- border-radius: 0px;
-}
-QToolTip {
-  background-color: #fffbdd;
-}
-QSplitter::handle {
-  image: url(separator.png);
-  height: 10px;
 }
 
 #RepoUpgradeLabel {
-  color: black;
-  background: #35b9ab;
+  color: cyan;
+  background: black;
 } 
 
 YQPkgVersionsView QWidget { background: black; }
-
-QY2HelpDialog
-{
-   qproperty-searchResultBackground: #666;
-   qproperty-searchResultForeground: #fff;
-}
-YQBarGraph {
-   qproperty-BackgroundColors: "#1F84AD,#6F368C,#E77929";
-   qproperty-ForegroundColors: "#fff,#fff,#fff";
-}
 
 #qt_calendar_navigationbar {
   background-color: black;

--- a/yast/cyan-black.qss
+++ b/yast/cyan-black.qss
@@ -1,0 +1,526 @@
+/* Richtext: installation_richtext.css */
+QMainWindow { background: black; }
+QFileDialog { background: black; }
+QWidget { background: black; color: cyan; font-size: 11pt; }
+QDialog { background: black; }
+YQWizard { background: black; }
+
+#LogoHBox {
+  background-color: #6da741;
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 cyan, stop: 0.5 #00a489, stop: 1 #6da741);
+  border-bottom: 1px solid cyan;
+}
+#DialogLogo {
+  background-image: url(logo.png);
+  min-width: 88px;
+  min-height: 58px;
+  margin-left: 10px;
+
+  margin-right: 10px;
+
+  background-color: none;
+}
+
+#work_area {
+  padding: 1em;
+  background-color: black;
+}
+
+YQLogView,
+QTextEdit,
+YQRichText > YQTextBrowser {
+  qproperty-frameShape: NoShape;
+  color: cyan;
+  border-radius: 0px;
+  border: 1px solid cyan;
+  background-color: black;
+  selection-background-color: cyan;
+  selection-color: black;
+}
+
+QFrame { background-color: black; color: cyan; }
+
+QLabel, YQDialog {
+  color: cyan;
+  background-color: black;
+  selection-background-color: cyan;
+  selection-color: black;
+}
+
+QHeaderView::section {
+  background-color: black;
+  color: cyan;
+  border: 1px outset cyan;
+  border-radius: 0px;
+  padding: 6px 8px;
+}
+QHeaderView::down-arrow { image: url(arr_down.png); padding-top: 2px; }
+QHeaderView::up-arrow { image: url(arr_up.png); padding-top: 2px; }
+
+QAbstractScrollArea { background-color: black; }
+
+QTreeView, QTreeWidget {
+  color: cyan;
+  background-color: black;
+  border: 1px solid cyan;
+  alternate-background-color: #2a2a2a;
+  selection-background-color: cyan;
+  selection-color: black;
+  border-radius: 0px;
+}
+
+QTableWidget,
+QTableView {
+  color: cyan;
+  background-color: black;
+  border: 1px solid cyan;
+  selection-background-color: cyan;
+  selection-color: black;
+  border-radius: 0px;
+}
+YQTree, YQTable {
+  color: cyan;
+  background-color: black;
+  selection-background-color: cyan;
+  selection-color: black;
+}
+
+YQPakageSelector {
+  color: cyan;
+  background-color: black;
+  border: 1px inset cyan;
+  selection-background-color: cyan;
+  selection-color: black;
+  border-radius: 0px; 
+}
+
+YQGenericDetailsView,
+YQDescriptionDialog,
+YQPkgDescriptionView { color: cyan; background-color: black; }
+
+YQPkgPatternCategoryItem { background-color: black; color: cyan; }
+
+QListWidget {
+  color: cyan;
+  background-color: black;
+  selection-background-color: cyan;
+  selection-color: black;
+}
+
+#DialogHeadingLeft {
+  font-family: Raleway, Sans-serif;
+  font: 24pt;
+  color: cyan;
+  margin-top: 100%;
+  margin-right: 20px;
+  qproperty-alignment:AlignRight;
+}
+#DialogHeadingTop {
+  font-family: Raleway, Sans-serif;
+  font: 24pt;
+  color: cyan;
+}
+
+QSpinBox,
+QDateEdit,
+QTimeEdit { color: cyan; background-color: #262626; padding: 3px 8px; min-height:24px; selection-background-color: cyan; selection-color: black; }
+
+QDateEdit::disabled, QTimeEdit::disabled{ color: gray; background-color: black; }
+
+YQWidgetCaption  { color: cyan; background-color: black; }
+YQWidgetCaption::disabled  { color: gray; background-color: black; }
+
+QLineEdit {
+  color: cyan;
+  background-color: #262626;
+  border-radius: 0px;
+  padding: 3px 8px;
+  min-height: 24px;
+  selection-background-color: cyan;
+  selection-color: black;
+  border: 1px solid cyan;
+}
+
+QLineEdit::focus {
+  border: 1px inset cyan;
+}
+
+QCheckBox { min-height: 20px; color: cyan; }
+
+QCheckBox::disabled { color: gray; }
+
+YQCheckBoxFrame::indicator:checked,
+QCheckBox::indicator:checked:enabled {
+  image: url(inst_checkbox-on.png);
+}
+YQCheckBoxFrame::indicator:unchecked,
+QCheckBox::indicator:unchecked:enabled {
+  image: url(inst_checkbox-off.png);
+}
+
+QCheckBox::indicator:checked:disabled {
+  image: url(inst_checkbox-on-disabled.png);
+}
+YQCheckBoxFrame::indicator:unchecked:disabled,
+QCheckBox::indicator:unchecked {
+  image: url(inst_checkbox-off-disabled.png);
+}
+
+QRadioButton {color: cyan }
+
+QRadioButton::disabled { color: gray; background-color: black; }
+
+QRadioButton::indicator:unchecked {
+   image: url(inst_radio-button-unchecked.png);
+}
+QRadioButton::indicator:checked {
+   image: url(inst_radio-button-checked.png);
+}
+QRadioButton::indicator:unchecked:disabled {
+   image: url(inst_radio-button-unchecked-disabled.png);
+}
+QRadioButton::indicator:checked:disabled {
+   image: url(inst_radio-button-checked-disabled.png);
+}
+
+YQMultiLineEdit QTextEdit { color: cyan; }
+
+QMessageBox { background-color: black; }
+
+.conflict QWidget { color: cyan; }
+
+YQMultiProgressMeter {
+  background-color: transparent;
+  border: 1px solid cyan;
+  border-radius: 0px;
+}
+
+YQProgressBar > YQWidgetCaption { margin-top: 20px; }
+
+/* Tab bars*/
+QTabWidget::pane {
+  border: none;
+}
+
+QTabBar
+{
+  qproperty-drawBase: 0;
+  /* Duplicate QTabBar::tab property.
+     Without this property, the tab space is calculated narrower and bold font
+     display messes up. See bnc#888589, bsc#948311 and QTBUG#8209 */
+  font-weight: bold;
+}
+QTabBar::tab {
+  color: cyan;
+  background: black;
+  border: 1px solid cyan;
+  font-weight: bold;
+  padding: 4px 8px;
+  min-width: 180px;
+  min-height: 24px;
+}
+
+QTabBar::tab:selected {
+  color: cyan;
+  background: black;
+  border: 1px solid cyan;
+  border-bottom: none;
+}
+
+QTabBar::tab:!selected:hover {
+  color: cyan;
+  background: #35b9ab;
+  border: 1px solid cyan;
+}
+
+QTabBar::tear {
+  background: black;
+  border: 1px solid cyan;
+  border-radius: 0px;
+}
+
+
+QComboBox {
+  border: 1px solid cyan;
+  border-radius: 0px;
+  color: cyan;
+  min-height: 24px;
+  padding: 3px 12px;
+  background: black;
+  font-weight: bold;
+  selection-background-color: cyan;
+  selection-color: black;
+}
+QComboBox::disabled {
+  color: gray;
+  background-color: black;
+  border: 1px solid gray;
+}
+QComboBox:focus {
+  background-color: cyan;
+  border: 1px solid cyan;
+  color: black;
+}
+/* QComboBox gets the "on" state when the popup is open */
+QComboBox:!editable:on, QComboBox::drop-down:editable:on {
+  color: gray;
+}
+QComboBox::drop-down { /* arrow part of the widget */
+  subcontrol-origin: padding;
+  subcontrol-position: top right;
+  width: 24px;
+  border: none;
+}
+QComboBox::down-arrow {
+  image: url(arr_down.png);
+}
+QComboBox::down-arrow:on { /* shift the arrow when popup is open */
+  image: url(arr_up.png);
+  top: 0px;
+  left: 0px;
+}
+QComboBox QAbstractItemView,
+QMenuBar {
+  background-color: black;
+  selection-background-color: cyan;
+  selection-color: black;
+}
+
+QMenuBar::item {
+  color: cyan;
+  spacing: 3px; /* spacing between menu bar items */
+  padding: 6px 0px ;
+  background: transparent;
+  border-radius: 0px;
+  margin: 6px 0px;
+}
+
+QMenuBar::item:selected { /* when selected using mouse or keyboard */
+  color: #fff;
+  background: #28ae73;
+ }
+
+QMenuBar::item:pressed {
+  color: cyan;
+  background: black;
+}
+QMenu {
+  color: cyan;
+  background: black;
+  border: 1px outset cyan;
+  selection-background-color: cyan;
+  selection-color: black;
+}
+QGroupBox {
+  border: 0px;
+  margin-top: 2.5ex;
+  margin-left: 10px;
+}
+QGroupBox::title {
+  subcontrol-origin: margin;
+  subcontrol-position: left top;
+  font-weight: bold;
+  color: cyan;
+}
+
+QPushButton {
+  border: 1px solid cyan;
+  border-radius: 0px;
+  background-color: black;
+  min-height: 24px;
+  min-width: 40px;
+  padding: 3px 12px;
+  color: cyan;
+  font-weight: bold;
+}
+QPushButton:focus, QPushButton:focus:default {
+  border: 1px solid cyan;
+}
+QPushButton:focus:default {
+  background-color: cyan;
+}
+QPushButton:disabled,
+QPushButton:default:disabled {
+  color: gray;
+  background-color: black;
+}
+QPushButton:default:pressed, QPushButton:pressed {
+  border: 1px solid black;
+  color: black;
+  background-color: cyan;
+}
+QPushButton:hover, QPushButton:default:hover  {
+  background-color: gray;
+  color: cyan;
+  border: 1px solid gray;
+}
+QPushButton:default {
+  border: 1px solid cyan;
+  color: black;
+  background-color: cyan;
+}
+/* odd dropdown button widget */
+QPushButton::menu-indicator,
+QPushButton::menu-indicator:pressed,
+QPushButton::menu-indicator:open {
+  subcontrol-origin: margin;
+  left: -7px;
+  subcontrol-position: right;
+  image: url(arr_down.png);
+}
+QPushButton:open { /* when the button has its menu open */
+  color: cyan;
+  background: black;
+  border: 1px solid cyan;
+}
+
+/* Tab Buttons               */
+
+QToolButton {
+  border: 1px solid cyan;
+  background-color: black;
+}
+QToolButton::left-arrow {
+  image: url(arr_left.png);
+}
+QToolButton::right-arrow {
+  image: url(arr_right.png);
+}
+QToolButton::up-arrow {
+  image: url(arr_lup.png);
+}
+QToolButton::down-arrow {
+  image: url(arr_down.png);
+}
+
+
+
+QProgressBar {
+  border: 1px solid cyan;
+  border-radius: 0px;
+  text-align: center;
+  color: black;
+  background-color: cyan;
+}
+QProgressBar::chunk {
+  background-color:  gray;
+  border: 1px solid gray;
+  border-radius: 2px;
+}
+
+/* Vertical Scrollbars        */
+
+QScrollBar:vertical {
+  width: 14px;
+  margin: 0px 0px 0px 0px;
+  background: cyan;
+  border: none;
+}
+QScrollBar::handle:vertical {
+  min-height: 16px;
+  background-color: black;
+  border-radius: 0px;
+}
+QScrollBar::add-line:vertical {
+  subcontrol-position: bottom;
+  subcontrol-origin: margin;
+  border: none;
+  height: 0px;
+  width: 0px;
+}
+QScrollBar::sub-line:vertical {
+  subcontrol-position: top;
+  subcontrol-origin: margin;
+  border: none;
+  height: 0px;
+  width: 0px;
+}
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical {
+  width: 0px;
+  height: 0px;
+}
+QScrollBar::up-arrow:vertical { background-image: none; }
+QScrollBar::down-arrow:vertical {  background-image: none; }
+
+/* Horizontal Scrollbars      */
+
+QScrollBar:horizontal {
+  height: 14px;
+  margin: 0px 0px 0px 0px;
+  background-color: #f1f0f2;
+  border: none;
+}
+QScrollBar::handle:horizontal {
+  min-width: 16px;
+  background-color: cyan;
+  border-radius: 0px;
+}
+QScrollBar::add-line:horizontal {
+  border: none;
+  background-color: transparent;
+  height: 0px;
+  width: 0px;
+  subcontrol-position: right;
+  subcontrol-origin: margin;
+}
+QScrollBar::sub-line:horizontal {
+  border: none;
+  background-color: transparent;
+  height: 0px;
+  width: 0px;
+  subcontrol-position: left;
+  subcontrol-origin: margin;
+}
+QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal {
+  width: 0px;
+}
+QScrollBar::right-arrow:horizontal { background-image: none; }
+QScrollBar::left-arrow:horizontal { background-image: none; }
+
+BusyBar {
+ qproperty-frameShape: NoShape;
+ border-width: 3px;
+ border: 1px solid cyan;
+ border-radius: 0px;
+}
+QToolTip {
+  background-color: #fffbdd;
+}
+QSplitter::handle {
+  image: url(separator.png);
+  height: 10px;
+}
+
+#RepoUpgradeLabel {
+  color: black;
+  background: #35b9ab;
+} 
+
+YQPkgVersionsView QWidget { background: black; }
+
+QY2HelpDialog
+{
+   qproperty-searchResultBackground: #666;
+   qproperty-searchResultForeground: #fff;
+}
+YQBarGraph {
+   qproperty-BackgroundColors: "#1F84AD,#6F368C,#E77929";
+   qproperty-ForegroundColors: "#fff,#fff,#fff";
+}
+
+#qt_calendar_navigationbar {
+  background-color: black;
+  color: cyan;
+}
+
+#qt_calendar_calendarview {
+  background-color: black;
+  color: cyan;
+}
+
+QComboBoxPrivateScroller
+{
+  background-color: black;
+  color: cyan;
+} 

--- a/yast/cyan-black_richtext.css
+++ b/yast/cyan-black_richtext.css
@@ -2,4 +2,3 @@ a { color: gray; }
 .red { color: rgb(237,28,36); }
 .blue { color: rgb(0,127,178); }
 .green { color: #537d23); }
-

--- a/yast/cyan-black_richtext.css
+++ b/yast/cyan-black_richtext.css
@@ -1,0 +1,5 @@
+a { color: gray; }
+.red { color: rgb(237,28,36); }
+.blue { color: rgb(0,127,178); }
+.green { color: #537d23); }
+

--- a/yast/highcontrast.qss
+++ b/yast/highcontrast.qss
@@ -1,3 +1,5 @@
+@import url("installation.qss");
+
 /* Richtext: highcontrast_richtext.css */
 QMainWindow { background: black; }
 QFileDialog { background: black; }
@@ -5,34 +7,14 @@ QWidget { background: black; color cyan; font-size: 11pt; }
 QDialog { background: black; }
 YQWizard { background: black; }
 
-#LogoHBox {
-  background-color: #6da741;
-  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
-    stop: 0 #173f4f, stop: 0.5 #00a489, stop: 1 #6da741);
-  border-bottom: 1px solid #173f4f;
-}
-#DialogLogo {
-  background-image: url(logo.png);
-  min-width: 88px;
-  min-height: 58px;
-  margin-left: 10px;
-
-  margin-right: 10px;
-
-  background-color: none;
-}
-
 #work_area {
-  padding: 1em;
   background-color: black;
 }
 
 YQLogView,
 QTextEdit,
 YQRichText > YQTextBrowser {
-  qproperty-frameShape: NoShape;
   color: cyan;
-  border-radius: 0px;
   border: 1px solid white;
   background-color: black;
   selection-background-color: #ffff00;
@@ -52,11 +34,7 @@ QHeaderView::section {
   background-color: black;
   color: #ffff00;
   border: 1px outset white;
-  border-radius: 0px;
-  padding: 6px 8px;
 }
-QHeaderView::down-arrow { image: url(arr_down.png); padding-top: 2px; }
-QHeaderView::up-arrow { image: url(arr_up.png); padding-top: 2px; }
 
 QAbstractScrollArea { background-color: black; }
 
@@ -67,7 +45,6 @@ QTreeView, QTreeWidget {
   alternate-background-color: #2a2a2a;
   selection-background-color: #ffff00;
   selection-color: black;
-  border-radius: 0px;
 }
 
 QTableWidget,
@@ -77,7 +54,6 @@ QTableView {
   border: 1px solid white;
   selection-background-color: #ffff00;
   selection-color: black;
-  border-radius: 0px;
 }
 YQTree, YQTable {
   color: cyan;
@@ -92,7 +68,6 @@ YQPakageSelector {
   border: 1px inset white;;
   selection-background-color: #ffff00;
   selection-color: black;
-  border-radius: 0px; 
 }
 
 YQGenericDetailsView,
@@ -109,22 +84,15 @@ QListWidget {
 }
 
 #DialogHeadingLeft {
-  font-family: Raleway, Sans-serif;
-  font: 24pt;
   color: #ffff00;
-  margin-top: 100%;
-  margin-right: 20px;
-  qproperty-alignment:AlignRight;
 }
 #DialogHeadingTop {
-  font-family: Raleway, Sans-serif;
-  font: 24pt;
   color: #ffff00;
 }
 
 QSpinBox,
 QDateEdit,
-QTimeEdit { color: cyan; background-color: black; padding: 3px 8px; min-height:24px; selection-background-color: #ffff00; selection-color: black; }
+QTimeEdit { color: cyan; background-color: black; selection-background-color: #ffff00; selection-color: black; }
 
 QDateEdit::disabled, QTimeEdit::disabled{ color: gray; background-color: black; }
 
@@ -134,9 +102,6 @@ YQWidgetCaption::disabled  {  color: gray; background-color:black; }
 QLineEdit {
   color: #00ff00;
   background-color: black;
-  border-radius: 0px;
-  padding: 3px 8px;
-  min-height: 24px;
   selection-background-color: #ffff00;
   selection-color: black;
   border: 1px solid white;;
@@ -148,81 +113,27 @@ QLineEdit:focus {
 
 QCheckBox { min-height: 20px; color: cyan; }
 
-QCheckBox::disabled { color: gray; }
-
-YQCheckBoxFrame::indicator:checked,
-QCheckBox::indicator:checked:enabled {
-  image: url(inst_checkbox-on.png);
-}
-YQCheckBoxFrame::indicator:unchecked,
-QCheckBox::indicator:unchecked:enabled {
-  image: url(inst_checkbox-off.png);
-}
-
-QCheckBox::indicator:checked:disabled {
-  image: url(inst_checkbox-on-disabled.png);
-}
-YQCheckBoxFrame::indicator:unchecked:disabled,
-QCheckBox::indicator:unchecked {
-  image: url(inst_checkbox-off-disabled.png);
-}
-
 QRadioButton {color: cyan }
 
 QRadioButton::disabled { color: gray; background-color: black; }
-
-QRadioButton::indicator:unchecked {
-   image: url(inst_radio-button-unchecked.png);
-}
-QRadioButton::indicator:checked {
-   image: url(inst_radio-button-checked.png);
-}
-QRadioButton::indicator:unchecked:disabled {
-   image: url(inst_radio-button-unchecked-disabled.png);
-}
-QRadioButton::indicator:checked:disabled {
-   image: url(inst_radio-button-checked-disabled.png);
-}
 
 YQMultiLineEdit QTextEdit { color: cyan; }
 
 QMessageBox { background-color: black; }
 
 YQMultiProgressMeter {
-  background-color: transparent;
   border: 1px solid white;;
-  border-radius: 0px;
 }
 
-YQProgressBar > YQWidgetCaption { margin-top: 20px; }
-
-/* Tab bars*/
-QTabWidget::pane {
-  border: none;
-}
-
-QTabBar
-{
-  qproperty-drawBase: 0;
-  /* Duplicate QTabBar::tab property.
-     Without this property, the tab space is calculated narrower and bold font
-     display messes up. See bnc#888589, bsc#948311 and QTBUG#8209 */
-  font-weight: bold;
-}
 QTabBar::tab {
   color: cyan;
 
   border: 1px solid white;;
-  font-weight: bold;
-  padding: 4px 8px;
-  min-width: 180px;
-  min-height: 24px;
 }
 
 QTabBar::tab:selected {
   color: white;
   border: 1px solid white;; 
-  border-bottom: none;
 }
 
 QTabBar::tab:!selected:hover {
@@ -234,18 +145,13 @@ QTabBar::tab:!selected:hover {
 QTabBar::tear {
   background: black;
   border: 1px solid white;;
-  border-radius: 0px;
 }
 
 
 QComboBox {
   border: 1px solid #656565;
-  border-radius: 0px;
   color: #00ff00;
-  min-height: 24px;
-  padding: 3px 12px;
   background: black;
-  font-weight: bold;
   selection-background-color: #ffff00;
   selection-color: black;
 }
@@ -262,20 +168,6 @@ QComboBox:focus {
 QComboBox:!editable:on, QComboBox::drop-down:editable:on {
   color: white;
 }
-QComboBox::drop-down { /* arrow part of the widget */
-  subcontrol-origin: padding;
-  subcontrol-position: top right;
-  width: 24px;
-  border: none;
-}
-QComboBox::down-arrow {
-  image: url(arr_down.png);
-}
-QComboBox::down-arrow:on { /* shift the arrow when popup is open */
-  image: url(arr_up.png);
-  top: 0px;
-  left: 0px;
-}
 QComboBox QAbstractItemView,
 QMenuBar {
   background-color: black;
@@ -285,11 +177,6 @@ QMenuBar {
 
 QMenuBar::item {
   color: cyan;
-  spacing: 3px; /* spacing between menu bar items */
-  padding: 6px 0px ;
-  background: transparent;
-  border-radius: 0px;
-  margin: 6px 0px;
 }
 
 QMenuBar::item:selected { /* when selected using mouse or keyboard */
@@ -311,27 +198,14 @@ QMenu {
 
 QMenu::item:disabled { color: gray; }
 
-QGroupBox {
-  border: 0px;
-  margin-top: 2.5ex;
-  margin-left: 10px;
-}
 QGroupBox::title {
-  subcontrol-origin: margin;
-  subcontrol-position: left top;
-  font-weight: bold;
   color: cyan;
 }
 
 QPushButton {
   border: 1px solid #00ff00;
-  border-radius: 0px;
   background-color: black;
-  min-height: 24px;
-  min-width: 40px;
-  padding: 3px 12px;
   color: #00ff00;
-  font-weight: bold;
 }
 QPushButton:focus, QPushButton:focus:default {
   border: 1px solid #ffff00;
@@ -360,15 +234,6 @@ QPushButton:default {
   color: black;
   background-color: #00ff00;
 }
-/* odd dropdown button widget */
-QPushButton::menu-indicator,
-QPushButton::menu-indicator:pressed,
-QPushButton::menu-indicator:open {
-  subcontrol-origin: margin;
-  left: -7px;
-  subcontrol-position: right;
-  image: url(arr_down.png);
-}
 QPushButton:open { /* when the button has its menu open */
   color: black;
   background: green;
@@ -381,25 +246,9 @@ QToolButton {
   border: 1px solid white;
   background-color: black;
 }
-QToolButton::left-arrow {
-  image: url(arr_left.png);
-}
-QToolButton::right-arrow {
-  image: url(arr_right.png);
-}
-QToolButton::up-arrow {
-  image: url(arr_lup.png);
-}
-QToolButton::down-arrow {
-  image: url(arr_down.png);
-}
-
-
 
 QProgressBar {
   border: 1px solid white;
-  border-radius: 0px;
-  text-align: center;
   color: #ff0000;
   background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
     stop: 0 #1b1b1b, stop: 1 #1f1f1f);
@@ -407,90 +256,24 @@ QProgressBar {
 QProgressBar::chunk {
   background-color:  #ffff00;
   border: 1px solid #ffff00;
-  border-radius: 0px;
 }
-
-/* Vertical Scrollbars        */
 
 QScrollBar:vertical {
-  width: 14px;
-  margin: 0px 0px 0px 0px;
   background-color: #222;
-  border: none;
 }
 QScrollBar::handle:vertical {
-  min-height: 16px;
   background-color: gray;
-  border-radius: 0px;
 }
-QScrollBar::add-line:vertical {
-  subcontrol-position: bottom;
-  subcontrol-origin: margin;
-  border: none;
-  height: 0px;
-  width: 0px;
-}
-QScrollBar::sub-line:vertical {
-  subcontrol-position: top;
-  subcontrol-origin: margin;
-  border: none;
-  height: 0px;
-  width: 0px;
-}
-QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical {
-  width: 0px;
-  height: 0px;
-}
-QScrollBar::up-arrow:vertical { background-image: none; }
-QScrollBar::down-arrow:vertical {  background-image: none; }
-
-/* Horizontal Scrollbars      */
 
 QScrollBar:horizontal {
-  height: 14px;
-  margin: 0px 0px 0px 0px;
   background-color: black;
-  border: none;
 }
 QScrollBar::handle:horizontal {
-  min-width: 16px;
   background-color: gray;
-  border-radius: 0px;
 }
-QScrollBar::add-line:horizontal {
-  border: none;
-  background-color: transparent;
-  height: 0px;
-  width: 0px;
-  subcontrol-position: right;
-  subcontrol-origin: margin;
-}
-QScrollBar::sub-line:horizontal {
-  border: none;
-  background-color: transparent;
-  height: 0px;
-  width: 0px;
-  subcontrol-position: left;
-  subcontrol-origin: margin;
-}
-QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal {
-  width: 0px;
-}
-QScrollBar::right-arrow:horizontal { background-image: none; }
-QScrollBar::left-arrow:horizontal { background-image: none; }
 
 BusyBar {
- qproperty-frameShape: NoShape;
- border-width: 3px;
  border: 1px solid white;
- border-radius: 0px;
-}
-QToolTip {
-  background-color: #fffbdd;
-}
-QSplitter::handle {
-  image: url(separator.png);
-  height: 10px;
 }
 
 #RepoUpgradeLabel {
@@ -499,21 +282,6 @@ QSplitter::handle {
 } 
 
 YQPkgVersionsView QWidget { background: #2d2d2d; }
-
-QY2HelpDialog
-{
-   qproperty-searchResultBackground: #666;
-   qproperty-searchResultForeground: #fff;
-}
-YQBarGraph {
-   qproperty-BackgroundColors: "#1F84AD,#6F368C,#E77929";
-   qproperty-ForegroundColors: "#fff,#fff,#fff";
-}
-
-#qt_calendar_navigationbar {
-  background-color: #35b9ab;
-  color: #173f4f;
-}
 
 #qt_calendar_calendarview {
   background-color: black;

--- a/yast/highcontrast.qss
+++ b/yast/highcontrast.qss
@@ -1,0 +1,527 @@
+/* Richtext: highcontrast_richtext.css */
+QMainWindow { background: black; }
+QFileDialog { background: black; }
+QWidget { background: black; color cyan; font-size: 11pt; }
+QDialog { background: black; }
+YQWizard { background: black; }
+
+#LogoHBox {
+  background-color: #6da741;
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 #173f4f, stop: 0.5 #00a489, stop: 1 #6da741);
+  border-bottom: 1px solid #173f4f;
+}
+#DialogLogo {
+  background-image: url(logo.png);
+  min-width: 88px;
+  min-height: 58px;
+  margin-left: 10px;
+
+  margin-right: 10px;
+
+  background-color: none;
+}
+
+#work_area {
+  padding: 1em;
+  background-color: black;
+}
+
+YQLogView,
+QTextEdit,
+YQRichText > YQTextBrowser {
+  qproperty-frameShape: NoShape;
+  color: cyan;
+  border-radius: 0px;
+  border: 1px solid white;
+  background-color: black;
+  selection-background-color: #ffff00;
+  selection-color: black;
+}
+
+QFrame { background-color: black; color: cyan; }
+
+QLabel, YQDialog {
+  color: cyan;
+  background-color: black;
+  selection-background-color: #ffff00;
+  selection-color: black;
+}
+
+QHeaderView::section {
+  background-color: black;
+  color: #ffff00;
+  border: 1px outset white;
+  border-radius: 0px;
+  padding: 6px 8px;
+}
+QHeaderView::down-arrow { image: url(arr_down.png); padding-top: 2px; }
+QHeaderView::up-arrow { image: url(arr_up.png); padding-top: 2px; }
+
+QAbstractScrollArea { background-color: black; }
+
+QTreeView, QTreeWidget {
+  color: cyan;
+  background-color: black;
+  border: 1px solid white;
+  alternate-background-color: #2a2a2a;
+  selection-background-color: #ffff00;
+  selection-color: black;
+  border-radius: 0px;
+}
+
+QTableWidget,
+QTableView {
+  color: cyan;
+  background-color: black;
+  border: 1px solid white;
+  selection-background-color: #ffff00;
+  selection-color: black;
+  border-radius: 0px;
+}
+YQTree, YQTable {
+  color: cyan;
+  background-color: black;
+  selection-background-color: #ffff00;
+  selection-color: black;
+}
+
+YQPakageSelector {
+  color: cyan;
+  background-color: black;
+  border: 1px inset white;;
+  selection-background-color: #ffff00;
+  selection-color: black;
+  border-radius: 0px; 
+}
+
+YQGenericDetailsView,
+YQDescriptionDialog,
+YQPkgDescriptionView { color: cyan; background-color: black; }
+
+YQPkgPatternCategoryItem { background-color: black; color: cyan; }
+
+QListWidget {
+  color: cyan;
+  background-color: black;
+  selection-background-color: #ffff00;
+  selection-color: black;
+}
+
+#DialogHeadingLeft {
+  font-family: Raleway, Sans-serif;
+  font: 24pt;
+  color: #ffff00;
+  margin-top: 100%;
+  margin-right: 20px;
+  qproperty-alignment:AlignRight;
+}
+#DialogHeadingTop {
+  font-family: Raleway, Sans-serif;
+  font: 24pt;
+  color: #ffff00;
+}
+
+QSpinBox,
+QDateEdit,
+QTimeEdit { color: cyan; background-color: black; padding: 3px 8px; min-height:24px; selection-background-color: #ffff00; selection-color: black; }
+
+QDateEdit::disabled, QTimeEdit::disabled{ color: gray; background-color: black; }
+
+YQWidgetCaption  { color: cyan; background-color:black; }
+YQWidgetCaption::disabled  {  color: gray; background-color:black; }
+
+QLineEdit {
+  color: #00ff00;
+  background-color: black;
+  border-radius: 0px;
+  padding: 3px 8px;
+  min-height: 24px;
+  selection-background-color: #ffff00;
+  selection-color: black;
+  border: 1px solid white;;
+}
+
+QLineEdit:focus {
+  border: 1px solid #ffff00;
+}
+
+QCheckBox { min-height: 20px; color: cyan; }
+
+QCheckBox::disabled { color: gray; }
+
+YQCheckBoxFrame::indicator:checked,
+QCheckBox::indicator:checked:enabled {
+  image: url(inst_checkbox-on.png);
+}
+YQCheckBoxFrame::indicator:unchecked,
+QCheckBox::indicator:unchecked:enabled {
+  image: url(inst_checkbox-off.png);
+}
+
+QCheckBox::indicator:checked:disabled {
+  image: url(inst_checkbox-on-disabled.png);
+}
+YQCheckBoxFrame::indicator:unchecked:disabled,
+QCheckBox::indicator:unchecked {
+  image: url(inst_checkbox-off-disabled.png);
+}
+
+QRadioButton {color: cyan }
+
+QRadioButton::disabled { color: gray; background-color: black; }
+
+QRadioButton::indicator:unchecked {
+   image: url(inst_radio-button-unchecked.png);
+}
+QRadioButton::indicator:checked {
+   image: url(inst_radio-button-checked.png);
+}
+QRadioButton::indicator:unchecked:disabled {
+   image: url(inst_radio-button-unchecked-disabled.png);
+}
+QRadioButton::indicator:checked:disabled {
+   image: url(inst_radio-button-checked-disabled.png);
+}
+
+YQMultiLineEdit QTextEdit { color: cyan; }
+
+QMessageBox { background-color: black; }
+
+YQMultiProgressMeter {
+  background-color: transparent;
+  border: 1px solid white;;
+  border-radius: 0px;
+}
+
+YQProgressBar > YQWidgetCaption { margin-top: 20px; }
+
+/* Tab bars*/
+QTabWidget::pane {
+  border: none;
+}
+
+QTabBar
+{
+  qproperty-drawBase: 0;
+  /* Duplicate QTabBar::tab property.
+     Without this property, the tab space is calculated narrower and bold font
+     display messes up. See bnc#888589, bsc#948311 and QTBUG#8209 */
+  font-weight: bold;
+}
+QTabBar::tab {
+  color: cyan;
+
+  border: 1px solid white;;
+  font-weight: bold;
+  padding: 4px 8px;
+  min-width: 180px;
+  min-height: 24px;
+}
+
+QTabBar::tab:selected {
+  color: white;
+  border: 1px solid white;; 
+  border-bottom: none;
+}
+
+QTabBar::tab:!selected:hover {
+  color: black;
+  background: white;
+  border: 1px solid black;
+}
+
+QTabBar::tear {
+  background: black;
+  border: 1px solid white;;
+  border-radius: 0px;
+}
+
+
+QComboBox {
+  border: 1px solid #656565;
+  border-radius: 0px;
+  color: #00ff00;
+  min-height: 24px;
+  padding: 3px 12px;
+  background: black;
+  font-weight: bold;
+  selection-background-color: #ffff00;
+  selection-color: black;
+}
+QComboBox::disabled {
+  color: gray;
+  background-color: black;
+  border: 1px solid white;;
+}
+QComboBox:focus {
+  border: 1px solid #ffff00;
+  color: #00ff00;
+}
+/* QComboBox gets the "on" state when the popup is open */
+QComboBox:!editable:on, QComboBox::drop-down:editable:on {
+  color: white;
+}
+QComboBox::drop-down { /* arrow part of the widget */
+  subcontrol-origin: padding;
+  subcontrol-position: top right;
+  width: 24px;
+  border: none;
+}
+QComboBox::down-arrow {
+  image: url(arr_down.png);
+}
+QComboBox::down-arrow:on { /* shift the arrow when popup is open */
+  image: url(arr_up.png);
+  top: 0px;
+  left: 0px;
+}
+QComboBox QAbstractItemView,
+QMenuBar {
+  background-color: black;
+  selection-background-color: #ffff00;
+  selection-color: black;
+}
+
+QMenuBar::item {
+  color: cyan;
+  spacing: 3px; /* spacing between menu bar items */
+  padding: 6px 0px ;
+  background: transparent;
+  border-radius: 0px;
+  margin: 6px 0px;
+}
+
+QMenuBar::item:selected { /* when selected using mouse or keyboard */
+  color: #fff;
+  background: black;
+ }
+
+QMenuBar::item:pressed {
+  color: #00ff00;
+  background: black;
+}
+QMenu {
+  color: cyan;
+  background: black;
+  border: 1px outset white;;
+  selection-background-color: #ffff00;
+  selection-color: black;
+}
+
+QMenu::item:disabled { color: gray; }
+
+QGroupBox {
+  border: 0px;
+  margin-top: 2.5ex;
+  margin-left: 10px;
+}
+QGroupBox::title {
+  subcontrol-origin: margin;
+  subcontrol-position: left top;
+  font-weight: bold;
+  color: cyan;
+}
+
+QPushButton {
+  border: 1px solid #00ff00;
+  border-radius: 0px;
+  background-color: black;
+  min-height: 24px;
+  min-width: 40px;
+  padding: 3px 12px;
+  color: #00ff00;
+  font-weight: bold;
+}
+QPushButton:focus, QPushButton:focus:default {
+  border: 1px solid #ffff00;
+}
+QPushButton:focus:default {
+  background-color: #ffff00;
+}
+QPushButton:disabled,
+QPushButton:default:disabled {
+  color: green;
+  background: #2d2d2d;
+  border: 1px solid green;
+}
+QPushButton:default:pressed, QPushButton:pressed {
+  border: 1px solid #ffff00;
+  color: #ffff00;
+  background-color: black;
+}
+QPushButton:hover, QPushButton:default:hover  {
+  background-color: #ffff00;
+  color: black;
+  border: 1px solid #ffff00;
+}
+QPushButton:default {
+  border: 1px solid #00ff00;
+  color: black;
+  background-color: #00ff00;
+}
+/* odd dropdown button widget */
+QPushButton::menu-indicator,
+QPushButton::menu-indicator:pressed,
+QPushButton::menu-indicator:open {
+  subcontrol-origin: margin;
+  left: -7px;
+  subcontrol-position: right;
+  image: url(arr_down.png);
+}
+QPushButton:open { /* when the button has its menu open */
+  color: black;
+  background: green;
+  border: 1px solid green;;
+}
+
+/* Tab Buttons               */
+
+QToolButton {
+  border: 1px solid white;
+  background-color: black;
+}
+QToolButton::left-arrow {
+  image: url(arr_left.png);
+}
+QToolButton::right-arrow {
+  image: url(arr_right.png);
+}
+QToolButton::up-arrow {
+  image: url(arr_lup.png);
+}
+QToolButton::down-arrow {
+  image: url(arr_down.png);
+}
+
+
+
+QProgressBar {
+  border: 1px solid white;
+  border-radius: 0px;
+  text-align: center;
+  color: #ff0000;
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+    stop: 0 #1b1b1b, stop: 1 #1f1f1f);
+}
+QProgressBar::chunk {
+  background-color:  #ffff00;
+  border: 1px solid #ffff00;
+  border-radius: 0px;
+}
+
+/* Vertical Scrollbars        */
+
+QScrollBar:vertical {
+  width: 14px;
+  margin: 0px 0px 0px 0px;
+  background-color: #222;
+  border: none;
+}
+QScrollBar::handle:vertical {
+  min-height: 16px;
+  background-color: gray;
+  border-radius: 0px;
+}
+QScrollBar::add-line:vertical {
+  subcontrol-position: bottom;
+  subcontrol-origin: margin;
+  border: none;
+  height: 0px;
+  width: 0px;
+}
+QScrollBar::sub-line:vertical {
+  subcontrol-position: top;
+  subcontrol-origin: margin;
+  border: none;
+  height: 0px;
+  width: 0px;
+}
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical {
+  width: 0px;
+  height: 0px;
+}
+QScrollBar::up-arrow:vertical { background-image: none; }
+QScrollBar::down-arrow:vertical {  background-image: none; }
+
+/* Horizontal Scrollbars      */
+
+QScrollBar:horizontal {
+  height: 14px;
+  margin: 0px 0px 0px 0px;
+  background-color: black;
+  border: none;
+}
+QScrollBar::handle:horizontal {
+  min-width: 16px;
+  background-color: gray;
+  border-radius: 0px;
+}
+QScrollBar::add-line:horizontal {
+  border: none;
+  background-color: transparent;
+  height: 0px;
+  width: 0px;
+  subcontrol-position: right;
+  subcontrol-origin: margin;
+}
+QScrollBar::sub-line:horizontal {
+  border: none;
+  background-color: transparent;
+  height: 0px;
+  width: 0px;
+  subcontrol-position: left;
+  subcontrol-origin: margin;
+}
+QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal {
+  width: 0px;
+}
+QScrollBar::right-arrow:horizontal { background-image: none; }
+QScrollBar::left-arrow:horizontal { background-image: none; }
+
+BusyBar {
+ qproperty-frameShape: NoShape;
+ border-width: 3px;
+ border: 1px solid white;
+ border-radius: 0px;
+}
+QToolTip {
+  background-color: #fffbdd;
+}
+QSplitter::handle {
+  image: url(separator.png);
+  height: 10px;
+}
+
+#RepoUpgradeLabel {
+  color: cyan;
+  background: black;
+} 
+
+YQPkgVersionsView QWidget { background: #2d2d2d; }
+
+QY2HelpDialog
+{
+   qproperty-searchResultBackground: #666;
+   qproperty-searchResultForeground: #fff;
+}
+YQBarGraph {
+   qproperty-BackgroundColors: "#1F84AD,#6F368C,#E77929";
+   qproperty-ForegroundColors: "#fff,#fff,#fff";
+}
+
+#qt_calendar_navigationbar {
+  background-color: #35b9ab;
+  color: #173f4f;
+}
+
+#qt_calendar_calendarview {
+  background-color: black;
+  color: cyan;
+}
+
+QComboBoxPrivateScroller
+{
+  background-color: black;
+  color: cyan;
+} 

--- a/yast/highcontrast_richtext.css
+++ b/yast/highcontrast_richtext.css
@@ -1,0 +1,4 @@
+a { color: #ffff00; }
+.red { color: #ff0000; }
+.blue { color: cyan; }
+.green { color: #00ff00; }

--- a/yast/white-black.qss
+++ b/yast/white-black.qss
@@ -1,0 +1,526 @@
+/* Richtext: white-black_richtext.css */
+QMainWindow { background: black; }
+QFileDialog { background: black; }
+QWidget { background: black; color: white; font-size: 11pt; }
+QDialog { background: black; }
+YQWizard { background: black; }
+
+#LogoHBox {
+  background-color: #6da741;
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 white, stop: 0.5 #00a489, stop: 1 #6da741);
+  border-bottom: 1px solid white;
+}
+#DialogLogo {
+  background-image: url(logo.png);
+  min-width: 88px;
+  min-height: 58px;
+  margin-left: 10px;
+
+  margin-right: 10px;
+
+  background-color: none;
+}
+
+#work_area {
+  padding: 1em;
+  background-color: black;
+}
+
+YQLogView,
+QTextEdit,
+YQRichText > YQTextBrowser {
+  qproperty-frameShape: NoShape;
+  color: white;
+  border-radius: 0px;
+  border: 1px solid white;
+  background-color: black;
+  selection-background-color: white;
+  selection-color: black;
+}
+
+QFrame { background-color: black; color: white; }
+
+QLabel, YQDialog {
+  color: white;
+  background-color: black;
+  selection-background-color: white;
+  selection-color: black;
+}
+
+QHeaderView::section {
+  background-color: black;
+  color: white;
+  border: 1px outset white;
+  border-radius: 0px;
+  padding: 6px 8px;
+}
+QHeaderView::down-arrow { image: url(arr_down.png); padding-top: 2px; }
+QHeaderView::up-arrow { image: url(arr_up.png); padding-top: 2px; }
+
+QAbstractScrollArea { background-color: black; }
+
+QTreeView, QTreeWidget {
+  color: white;
+  background-color: black;
+  border: 1px solid white;
+  alternate-background-color: #2a2a2a;
+  selection-background-color: white;
+  selection-color: black;
+  border-radius: 0px;
+}
+
+QTableWidget,
+QTableView {
+  color: white;
+  background-color: black;
+  border: 1px solid white;
+  selection-background-color: white;
+  selection-color: black;
+  border-radius: 0px;
+}
+YQTree, YQTable {
+  color: white;
+  background-color: black;
+  selection-background-color: white;
+  selection-color: black;
+}
+
+YQPakageSelector {
+  color: white;
+  background-color: black;
+  border: 1px inset white;
+  selection-background-color: white;
+  selection-color: black;
+  border-radius: 0px; 
+}
+
+YQGenericDetailsView,
+YQDescriptionDialog,
+YQPkgDescriptionView { color: white; background-color: black; }
+
+YQPkgPatternCategoryItem { background-color: black; color: white; }
+
+QListWidget {
+  color: white;
+  background-color: black;
+  selection-background-color: white;
+  selection-color: black;
+}
+
+#DialogHeadingLeft {
+  font-family: Raleway, Sans-serif;
+  font: 24pt;
+  color: white;
+  margin-top: 100%;
+  margin-right: 20px;
+  qproperty-alignment:AlignRight;
+}
+#DialogHeadingTop {
+  font-family: Raleway, Sans-serif;
+  font: 24pt;
+  color: white;
+}
+
+QSpinBox,
+QDateEdit,
+QTimeEdit { color: white; background-color: #262626; padding: 3px 8px; min-height:24px; selection-background-color: white; selection-color: black; }
+
+QDateEdit::disabled, QTimeEdit::disabled{ color: gray; background-color: black; }
+
+YQWidgetCaption  { color: white; background-color: black; }
+YQWidgetCaption::disabled  { color: gray; background-color: black; }
+
+QLineEdit {
+  color: white;
+  background-color: #262626;
+  border-radius: 0px;
+  padding: 3px 8px;
+  min-height: 24px;
+  selection-background-color: white;
+  selection-color: black;
+  border: 1px solid white;
+}
+
+QLineEdit::focus {
+  border: 1px inset white;
+}
+
+QCheckBox { min-height: 20px; color: white; }
+
+QCheckBox::disabled { color: gray; }
+
+YQCheckBoxFrame::indicator:checked,
+QCheckBox::indicator:checked:enabled {
+  image: url(inst_checkbox-on.png);
+}
+YQCheckBoxFrame::indicator:unchecked,
+QCheckBox::indicator:unchecked:enabled {
+  image: url(inst_checkbox-off.png);
+}
+
+QCheckBox::indicator:checked:disabled {
+  image: url(inst_checkbox-on-disabled.png);
+}
+YQCheckBoxFrame::indicator:unchecked:disabled,
+QCheckBox::indicator:unchecked {
+  image: url(inst_checkbox-off-disabled.png);
+}
+
+QRadioButton {color: white }
+
+QRadioButton::disabled { color: gray; background-color: black; }
+
+QRadioButton::indicator:unchecked {
+   image: url(inst_radio-button-unchecked.png);
+}
+QRadioButton::indicator:checked {
+   image: url(inst_radio-button-checked.png);
+}
+QRadioButton::indicator:unchecked:disabled {
+   image: url(inst_radio-button-unchecked-disabled.png);
+}
+QRadioButton::indicator:checked:disabled {
+   image: url(inst_radio-button-checked-disabled.png);
+}
+
+YQMultiLineEdit QTextEdit { color: white; }
+
+QMessageBox { background-color: black; }
+
+.conflict QWidget { color: white; }
+
+YQMultiProgressMeter {
+  background-color: transparent;
+  border: 1px solid white;
+  border-radius: 0px;
+}
+
+YQProgressBar > YQWidgetCaption { margin-top: 20px; }
+
+/* Tab bars*/
+QTabWidget::pane {
+  border: none;
+}
+
+QTabBar
+{
+  qproperty-drawBase: 0;
+  /* Duplicate QTabBar::tab property.
+     Without this property, the tab space is calculated narrower and bold font
+     display messes up. See bnc#888589, bsc#948311 and QTBUG#8209 */
+  font-weight: bold;
+}
+QTabBar::tab {
+  color: white;
+  background: black;
+  border: 1px solid white;
+  font-weight: bold;
+  padding: 4px 8px;
+  min-width: 180px;
+  min-height: 24px;
+}
+
+QTabBar::tab:selected {
+  color: white;
+  background: black;
+  border: 1px solid white;
+  border-bottom: none;
+}
+
+QTabBar::tab:!selected:hover {
+  color: white;
+  background: #35b9ab;
+  border: 1px solid white;
+}
+
+QTabBar::tear {
+  background: black;
+  border: 1px solid white;
+  border-radius: 0px;
+}
+
+
+QComboBox {
+  border: 1px solid white;
+  border-radius: 0px;
+  color: white;
+  min-height: 24px;
+  padding: 3px 12px;
+  background: black;
+  font-weight: bold;
+  selection-background-color: white;
+  selection-color: black;
+}
+QComboBox::disabled {
+  color: gray;
+  background-color: black;
+  border: 1px solid gray;
+}
+QComboBox:focus {
+  background-color: white;
+  border: 1px solid white;
+  color: black;
+}
+/* QComboBox gets the "on" state when the popup is open */
+QComboBox:!editable:on, QComboBox::drop-down:editable:on {
+  color: gray;
+}
+QComboBox::drop-down { /* arrow part of the widget */
+  subcontrol-origin: padding;
+  subcontrol-position: top right;
+  width: 24px;
+  border: none;
+}
+QComboBox::down-arrow {
+  image: url(arr_down.png);
+}
+QComboBox::down-arrow:on { /* shift the arrow when popup is open */
+  image: url(arr_up.png);
+  top: 0px;
+  left: 0px;
+}
+QComboBox QAbstractItemView,
+QMenuBar {
+  background-color: black;
+  selection-background-color: white;
+  selection-color: black;
+}
+
+QMenuBar::item {
+  color: white;
+  spacing: 3px; /* spacing between menu bar items */
+  padding: 6px 0px ;
+  background: transparent;
+  border-radius: 0px;
+  margin: 6px 0px;
+}
+
+QMenuBar::item:selected { /* when selected using mouse or keyboard */
+  color: #fff;
+  background: #28ae73;
+ }
+
+QMenuBar::item:pressed {
+  color: white;
+  background: black;
+}
+QMenu {
+  color: white;
+  background: black;
+  border: 1px outset white;
+  selection-background-color: white;
+  selection-color: black;
+}
+QGroupBox {
+  border: 0px;
+  margin-top: 2.5ex;
+  margin-left: 10px;
+}
+QGroupBox::title {
+  subcontrol-origin: margin;
+  subcontrol-position: left top;
+  font-weight: bold;
+  color: white;
+}
+
+QPushButton {
+  border: 1px solid white;
+  border-radius: 0px;
+  background-color: black;
+  min-height: 24px;
+  min-width: 40px;
+  padding: 3px 12px;
+  color: white;
+  font-weight: bold;
+}
+QPushButton:focus, QPushButton:focus:default {
+  border: 1px solid white;
+}
+QPushButton:focus:default {
+  background-color: white;
+}
+QPushButton:disabled,
+QPushButton:default:disabled {
+  color: gray;
+  background-color: black;
+}
+QPushButton:default:pressed, QPushButton:pressed {
+  border: 1px solid black;
+  color: black;
+  background-color: white;
+}
+QPushButton:hover, QPushButton:default:hover  {
+  background-color: gray;
+  color: white;
+  border: 1px solid gray;
+}
+QPushButton:default {
+  border: 1px solid white;
+  color: black;
+  background-color: white;
+}
+/* odd dropdown button widget */
+QPushButton::menu-indicator,
+QPushButton::menu-indicator:pressed,
+QPushButton::menu-indicator:open {
+  subcontrol-origin: margin;
+  left: -7px;
+  subcontrol-position: right;
+  image: url(arr_down.png);
+}
+QPushButton:open { /* when the button has its menu open */
+  color: white;
+  background: black;
+  border: 1px solid white;
+}
+
+/* Tab Buttons               */
+
+QToolButton {
+  border: 1px solid white;
+  background-color: black;
+}
+QToolButton::left-arrow {
+  image: url(arr_left.png);
+}
+QToolButton::right-arrow {
+  image: url(arr_right.png);
+}
+QToolButton::up-arrow {
+  image: url(arr_lup.png);
+}
+QToolButton::down-arrow {
+  image: url(arr_down.png);
+}
+
+
+
+QProgressBar {
+  border: 1px solid white;
+  border-radius: 0px;
+  text-align: center;
+  color: black;
+  background-color: white;
+}
+QProgressBar::chunk {
+  background-color:  gray;
+  border: 1px solid gray;
+  border-radius: 2px;
+}
+
+/* Vertical Scrollbars        */
+
+QScrollBar:vertical {
+  width: 14px;
+  margin: 0px 0px 0px 0px;
+  background: white;
+  border: none;
+}
+QScrollBar::handle:vertical {
+  min-height: 16px;
+  background-color: black;
+  border-radius: 0px;
+}
+QScrollBar::add-line:vertical {
+  subcontrol-position: bottom;
+  subcontrol-origin: margin;
+  border: none;
+  height: 0px;
+  width: 0px;
+}
+QScrollBar::sub-line:vertical {
+  subcontrol-position: top;
+  subcontrol-origin: margin;
+  border: none;
+  height: 0px;
+  width: 0px;
+}
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical {
+  width: 0px;
+  height: 0px;
+}
+QScrollBar::up-arrow:vertical { background-image: none; }
+QScrollBar::down-arrow:vertical {  background-image: none; }
+
+/* Horizontal Scrollbars      */
+
+QScrollBar:horizontal {
+  height: 14px;
+  margin: 0px 0px 0px 0px;
+  background-color: #f1f0f2;
+  border: none;
+}
+QScrollBar::handle:horizontal {
+  min-width: 16px;
+  background-color: white;
+  border-radius: 0px;
+}
+QScrollBar::add-line:horizontal {
+  border: none;
+  background-color: transparent;
+  height: 0px;
+  width: 0px;
+  subcontrol-position: right;
+  subcontrol-origin: margin;
+}
+QScrollBar::sub-line:horizontal {
+  border: none;
+  background-color: transparent;
+  height: 0px;
+  width: 0px;
+  subcontrol-position: left;
+  subcontrol-origin: margin;
+}
+QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal {
+  width: 0px;
+}
+QScrollBar::right-arrow:horizontal { background-image: none; }
+QScrollBar::left-arrow:horizontal { background-image: none; }
+
+BusyBar {
+ qproperty-frameShape: NoShape;
+ border-width: 3px;
+ border: 1px solid white;
+ border-radius: 0px;
+}
+QToolTip {
+  background-color: #fffbdd;
+}
+QSplitter::handle {
+  image: url(separator.png);
+  height: 10px;
+}
+
+#RepoUpgradeLabel {
+  color: black;
+  background: #35b9ab;
+} 
+
+YQPkgVersionsView QWidget { background: black; }
+
+QY2HelpDialog
+{
+   qproperty-searchResultBackground: #666;
+   qproperty-searchResultForeground: #fff;
+}
+YQBarGraph {
+   qproperty-BackgroundColors: "#1F84AD,#6F368C,#E77929";
+   qproperty-ForegroundColors: "#fff,#fff,#fff";
+}
+
+#qt_calendar_navigationbar {
+  background-color: black;
+  color: white;
+}
+
+#qt_calendar_calendarview {
+  background-color: black;
+  color: white;
+}
+
+QComboBoxPrivateScroller
+{
+  background-color: black;
+  color: white;
+} 

--- a/yast/white-black.qss
+++ b/yast/white-black.qss
@@ -1,3 +1,5 @@
+@import url("installation.qss");
+
 /* Richtext: white-black_richtext.css */
 QMainWindow { background: black; }
 QFileDialog { background: black; }
@@ -6,33 +8,19 @@ QDialog { background: black; }
 YQWizard { background: black; }
 
 #LogoHBox {
-  background-color: #6da741;
   background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
     stop: 0 white, stop: 0.5 #00a489, stop: 1 #6da741);
   border-bottom: 1px solid white;
 }
-#DialogLogo {
-  background-image: url(logo.png);
-  min-width: 88px;
-  min-height: 58px;
-  margin-left: 10px;
-
-  margin-right: 10px;
-
-  background-color: none;
-}
 
 #work_area {
-  padding: 1em;
   background-color: black;
 }
 
 YQLogView,
 QTextEdit,
 YQRichText > YQTextBrowser {
-  qproperty-frameShape: NoShape;
   color: white;
-  border-radius: 0px;
   border: 1px solid white;
   background-color: black;
   selection-background-color: white;
@@ -52,11 +40,7 @@ QHeaderView::section {
   background-color: black;
   color: white;
   border: 1px outset white;
-  border-radius: 0px;
-  padding: 6px 8px;
 }
-QHeaderView::down-arrow { image: url(arr_down.png); padding-top: 2px; }
-QHeaderView::up-arrow { image: url(arr_up.png); padding-top: 2px; }
 
 QAbstractScrollArea { background-color: black; }
 
@@ -64,10 +48,8 @@ QTreeView, QTreeWidget {
   color: white;
   background-color: black;
   border: 1px solid white;
-  alternate-background-color: #2a2a2a;
   selection-background-color: white;
   selection-color: black;
-  border-radius: 0px;
 }
 
 QTableWidget,
@@ -77,7 +59,6 @@ QTableView {
   border: 1px solid white;
   selection-background-color: white;
   selection-color: black;
-  border-radius: 0px;
 }
 YQTree, YQTable {
   color: white;
@@ -92,7 +73,6 @@ YQPakageSelector {
   border: 1px inset white;
   selection-background-color: white;
   selection-color: black;
-  border-radius: 0px; 
 }
 
 YQGenericDetailsView,
@@ -109,22 +89,15 @@ QListWidget {
 }
 
 #DialogHeadingLeft {
-  font-family: Raleway, Sans-serif;
-  font: 24pt;
   color: white;
-  margin-top: 100%;
-  margin-right: 20px;
-  qproperty-alignment:AlignRight;
 }
 #DialogHeadingTop {
-  font-family: Raleway, Sans-serif;
-  font: 24pt;
   color: white;
 }
 
 QSpinBox,
 QDateEdit,
-QTimeEdit { color: white; background-color: #262626; padding: 3px 8px; min-height:24px; selection-background-color: white; selection-color: black; }
+QTimeEdit { color: white; background-color: #262626; selection-background-color: white; selection-color: black; }
 
 QDateEdit::disabled, QTimeEdit::disabled{ color: gray; background-color: black; }
 
@@ -134,9 +107,6 @@ YQWidgetCaption::disabled  { color: gray; background-color: black; }
 QLineEdit {
   color: white;
   background-color: #262626;
-  border-radius: 0px;
-  padding: 3px 8px;
-  min-height: 24px;
   selection-background-color: white;
   selection-color: black;
   border: 1px solid white;
@@ -148,41 +118,9 @@ QLineEdit::focus {
 
 QCheckBox { min-height: 20px; color: white; }
 
-QCheckBox::disabled { color: gray; }
-
-YQCheckBoxFrame::indicator:checked,
-QCheckBox::indicator:checked:enabled {
-  image: url(inst_checkbox-on.png);
-}
-YQCheckBoxFrame::indicator:unchecked,
-QCheckBox::indicator:unchecked:enabled {
-  image: url(inst_checkbox-off.png);
-}
-
-QCheckBox::indicator:checked:disabled {
-  image: url(inst_checkbox-on-disabled.png);
-}
-YQCheckBoxFrame::indicator:unchecked:disabled,
-QCheckBox::indicator:unchecked {
-  image: url(inst_checkbox-off-disabled.png);
-}
-
 QRadioButton {color: white }
 
 QRadioButton::disabled { color: gray; background-color: black; }
-
-QRadioButton::indicator:unchecked {
-   image: url(inst_radio-button-unchecked.png);
-}
-QRadioButton::indicator:checked {
-   image: url(inst_radio-button-checked.png);
-}
-QRadioButton::indicator:unchecked:disabled {
-   image: url(inst_radio-button-unchecked-disabled.png);
-}
-QRadioButton::indicator:checked:disabled {
-   image: url(inst_radio-button-checked-disabled.png);
-}
 
 YQMultiLineEdit QTextEdit { color: white; }
 
@@ -191,64 +129,36 @@ QMessageBox { background-color: black; }
 .conflict QWidget { color: white; }
 
 YQMultiProgressMeter {
-  background-color: transparent;
   border: 1px solid white;
-  border-radius: 0px;
 }
 
-YQProgressBar > YQWidgetCaption { margin-top: 20px; }
-
-/* Tab bars*/
-QTabWidget::pane {
-  border: none;
-}
-
-QTabBar
-{
-  qproperty-drawBase: 0;
-  /* Duplicate QTabBar::tab property.
-     Without this property, the tab space is calculated narrower and bold font
-     display messes up. See bnc#888589, bsc#948311 and QTBUG#8209 */
-  font-weight: bold;
-}
 QTabBar::tab {
   color: white;
   background: black;
   border: 1px solid white;
-  font-weight: bold;
-  padding: 4px 8px;
-  min-width: 180px;
-  min-height: 24px;
 }
 
 QTabBar::tab:selected {
   color: white;
   background: black;
   border: 1px solid white;
-  border-bottom: none;
 }
 
 QTabBar::tab:!selected:hover {
   color: white;
-  background: #35b9ab;
   border: 1px solid white;
 }
 
 QTabBar::tear {
   background: black;
   border: 1px solid white;
-  border-radius: 0px;
 }
 
 
 QComboBox {
   border: 1px solid white;
-  border-radius: 0px;
   color: white;
-  min-height: 24px;
-  padding: 3px 12px;
   background: black;
-  font-weight: bold;
   selection-background-color: white;
   selection-color: black;
 }
@@ -266,20 +176,6 @@ QComboBox:focus {
 QComboBox:!editable:on, QComboBox::drop-down:editable:on {
   color: gray;
 }
-QComboBox::drop-down { /* arrow part of the widget */
-  subcontrol-origin: padding;
-  subcontrol-position: top right;
-  width: 24px;
-  border: none;
-}
-QComboBox::down-arrow {
-  image: url(arr_down.png);
-}
-QComboBox::down-arrow:on { /* shift the arrow when popup is open */
-  image: url(arr_up.png);
-  top: 0px;
-  left: 0px;
-}
 QComboBox QAbstractItemView,
 QMenuBar {
   background-color: black;
@@ -289,11 +185,6 @@ QMenuBar {
 
 QMenuBar::item {
   color: white;
-  spacing: 3px; /* spacing between menu bar items */
-  padding: 6px 0px ;
-  background: transparent;
-  border-radius: 0px;
-  margin: 6px 0px;
 }
 
 QMenuBar::item:selected { /* when selected using mouse or keyboard */
@@ -312,27 +203,15 @@ QMenu {
   selection-background-color: white;
   selection-color: black;
 }
-QGroupBox {
-  border: 0px;
-  margin-top: 2.5ex;
-  margin-left: 10px;
-}
+
 QGroupBox::title {
-  subcontrol-origin: margin;
-  subcontrol-position: left top;
-  font-weight: bold;
   color: white;
 }
 
 QPushButton {
   border: 1px solid white;
-  border-radius: 0px;
   background-color: black;
-  min-height: 24px;
-  min-width: 40px;
-  padding: 3px 12px;
   color: white;
-  font-weight: bold;
 }
 QPushButton:focus, QPushButton:focus:default {
   border: 1px solid white;
@@ -360,154 +239,42 @@ QPushButton:default {
   color: black;
   background-color: white;
 }
-/* odd dropdown button widget */
-QPushButton::menu-indicator,
-QPushButton::menu-indicator:pressed,
-QPushButton::menu-indicator:open {
-  subcontrol-origin: margin;
-  left: -7px;
-  subcontrol-position: right;
-  image: url(arr_down.png);
-}
 QPushButton:open { /* when the button has its menu open */
   color: white;
   background: black;
   border: 1px solid white;
 }
 
-/* Tab Buttons               */
-
 QToolButton {
   border: 1px solid white;
   background-color: black;
 }
-QToolButton::left-arrow {
-  image: url(arr_left.png);
-}
-QToolButton::right-arrow {
-  image: url(arr_right.png);
-}
-QToolButton::up-arrow {
-  image: url(arr_lup.png);
-}
-QToolButton::down-arrow {
-  image: url(arr_down.png);
-}
-
-
 
 QProgressBar {
   border: 1px solid white;
-  border-radius: 0px;
-  text-align: center;
   color: black;
   background-color: white;
 }
-QProgressBar::chunk {
-  background-color:  gray;
-  border: 1px solid gray;
-  border-radius: 2px;
-}
-
-/* Vertical Scrollbars        */
-
 QScrollBar:vertical {
-  width: 14px;
-  margin: 0px 0px 0px 0px;
   background: white;
-  border: none;
 }
 QScrollBar::handle:vertical {
-  min-height: 16px;
   background-color: black;
-  border-radius: 0px;
-}
-QScrollBar::add-line:vertical {
-  subcontrol-position: bottom;
-  subcontrol-origin: margin;
-  border: none;
-  height: 0px;
-  width: 0px;
-}
-QScrollBar::sub-line:vertical {
-  subcontrol-position: top;
-  subcontrol-origin: margin;
-  border: none;
-  height: 0px;
-  width: 0px;
-}
-QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical {
-  width: 0px;
-  height: 0px;
-}
-QScrollBar::up-arrow:vertical { background-image: none; }
-QScrollBar::down-arrow:vertical {  background-image: none; }
-
-/* Horizontal Scrollbars      */
-
-QScrollBar:horizontal {
-  height: 14px;
-  margin: 0px 0px 0px 0px;
-  background-color: #f1f0f2;
-  border: none;
 }
 QScrollBar::handle:horizontal {
-  min-width: 16px;
   background-color: white;
-  border-radius: 0px;
 }
-QScrollBar::add-line:horizontal {
-  border: none;
-  background-color: transparent;
-  height: 0px;
-  width: 0px;
-  subcontrol-position: right;
-  subcontrol-origin: margin;
-}
-QScrollBar::sub-line:horizontal {
-  border: none;
-  background-color: transparent;
-  height: 0px;
-  width: 0px;
-  subcontrol-position: left;
-  subcontrol-origin: margin;
-}
-QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal {
-  width: 0px;
-}
-QScrollBar::right-arrow:horizontal { background-image: none; }
-QScrollBar::left-arrow:horizontal { background-image: none; }
 
 BusyBar {
- qproperty-frameShape: NoShape;
- border-width: 3px;
  border: 1px solid white;
- border-radius: 0px;
-}
-QToolTip {
-  background-color: #fffbdd;
-}
-QSplitter::handle {
-  image: url(separator.png);
-  height: 10px;
 }
 
 #RepoUpgradeLabel {
-  color: black;
-  background: #35b9ab;
+  color: white;
+  background: black;
 } 
 
 YQPkgVersionsView QWidget { background: black; }
-
-QY2HelpDialog
-{
-   qproperty-searchResultBackground: #666;
-   qproperty-searchResultForeground: #fff;
-}
-YQBarGraph {
-   qproperty-BackgroundColors: "#1F84AD,#6F368C,#E77929";
-   qproperty-ForegroundColors: "#fff,#fff,#fff";
-}
 
 #qt_calendar_navigationbar {
   background-color: black;

--- a/yast/white-black_richtext.css
+++ b/yast/white-black_richtext.css
@@ -2,4 +2,3 @@ a { color: gray; }
 .red { color: rgb(237,28,36); }
 .blue { color: rgb(0,127,178); }
 .green { color: #537d23); }
-

--- a/yast/white-black_richtext.css
+++ b/yast/white-black_richtext.css
@@ -1,0 +1,5 @@
+a { color: gray; }
+.red { color: rgb(237,28,36); }
+.blue { color: rgb(0,127,178); }
+.green { color: #537d23); }
+


### PR DESCRIPTION
This PR contains a first attempt to provide highcontrast style sheets for the installer. A lot of work remains to be done (logos and graphical elements, etc.), but now we need feedback from users and, of course, help from our UI/UX team.

Support for setting a `screenmode` is available in the latest version of gfxboot (4.5.17). On the other hand, libyui-qt 2.46.29 allows to use the `shift+F4` shortcut to enable the highcontrast mode.

Below you'll find screenshots of the included modes.

# White/Black

![white-black-opensuse](https://cloud.githubusercontent.com/assets/15836/19435334/faf479c2-9461-11e6-8885-bff496986a15.png)

# Cyan/Black

![cyan-black-opensuse](https://cloud.githubusercontent.com/assets/15836/19435341/02a44f12-9462-11e6-9c45-7535f570186c.png)

# Cyan/Green/Yellow/Black

![highcontrast-opensuse](https://cloud.githubusercontent.com/assets/15836/19435351/0eb87030-9462-11e6-9f38-93e5c700bfc2.png)


