### PR TITLE
Add an autostart file that runs on login and grants X11 access  to root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,8 @@ install: # do not add requires here, this runs from generated openSUSE
 
 	install -D xfce/splash.png ${DESTDIR}/usr/share/pixmaps/xfce4-splash-openSUSE.png
 
+	install -D -m 0644 xdg/xhost-grant-root.desktop ${DESTDIR}/etc/xdg/autostart/xhost-grant-root.desktop
+
 clean: ${CLEAN_DEPS}
 	rmdir openSUSE
 

--- a/xdg/xhost-grant-root.desktop
+++ b/xdg/xhost-grant-root.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=X11 root access
+Comment=Grant X11 access for root
+Exec=xhost +SI:localuser:root
+Type=Application
+Terminal=false
+NoDisplay=true


### PR DESCRIPTION
This allows graphical applications to run as root, which is required for YaST (bsc#955101, fate#322297)

Cherry-picked from 6a1221c39