### PR TITLE
add title properties to grub2 theme (boo#1076577)

### DIFF
--- a/boot/grub2/theme/theme.txt
+++ b/boot/grub2/theme/theme.txt
@@ -3,6 +3,9 @@
 desktop-color: "#0D202F"
 
 title-text: ""
+title-color: "#fff"
+title-font: "DejaVu Sans Bold 14"
+
 terminal-font: "Gnu Unifont Mono Regular 16"
 
 + image {


### PR DESCRIPTION
Even if not used directly in the running system, this helps
installation-images which reuses the theme.