### PR TITLE
add title properties to grub2 theme (boo#1076577)

### DIFF
--- a/grub2/theme/theme.txt
+++ b/grub2/theme/theme.txt
@@ -3,6 +3,8 @@
 desktop-image: "background.png"
 
 title-text: ""
+title-color: "#fff"
+title-font: "DejaVu Sans Bold 14"
 
 terminal-box: "terminal_box_*.png"
 terminal-font: "Gnu Unifont Mono Regular 16"


### PR DESCRIPTION
Even if not used directly in the running system, this helps
installation-images which reuses the theme.