### PR TITLE
Don't hard-code the system role text color (bsc#1087399).

### DIFF
--- a/yast/cyan-black_richtext.css
+++ b/yast/cyan-black_richtext.css
@@ -1,4 +1,5 @@
 a { color: gray; }
+a.dontlooklikealink { color: cyan; text-decoration: none; }
 .red { color: rgb(237,28,36); }
 .blue { color: rgb(0,127,178); }
 .green { color: #537d23); }

--- a/yast/highcontrast_richtext.css
+++ b/yast/highcontrast_richtext.css
@@ -1,4 +1,5 @@
 a { color: #ffff00; }
+a.dontlooklikealink { color: cyan; text-decoration: none; }
 .red { color: #ff0000; }
 .blue { color: cyan; }
 .green { color: #00ff00; }

--- a/yast/installation_richtext.css
+++ b/yast/installation_richtext.css
@@ -1,4 +1,5 @@
 a { color: #00a489; }
+a.dontlooklikealink { color: #333; text-decoration: none; }
 .red { color: #FF3C3C; }
 .blue { color: #21a4df; }
 .green { color: #6da741; }

--- a/yast/richtext.css
+++ b/yast/richtext.css
@@ -1,4 +1,5 @@
 a { color: #537d23; }
+a.dontlooklikealink { color: #333; text-decoration: none; }
 .red { color: rgb(237,28,36); }
 .blue { color: rgb(0,127,178); }
 .green { color: #537d23); }

--- a/yast/white-black_richtext.css
+++ b/yast/white-black_richtext.css
@@ -1,4 +1,5 @@
 a { color: gray; }
+a.dontlooklikealink { color: white; text-decoration: none; }
 .red { color: rgb(237,28,36); }
 .blue { color: rgb(0,127,178); }
 .green { color: #537d23); }


### PR DESCRIPTION
The hardcoding is removed in
  https://github.com/yast/yast-installation/pull/683
and here we apply the desired styling: for widgets that are simulated by
a hyperlink, make the label look NOT like a hyperlink.

Yayyy!
![roles-styled-kubic](https://user-images.githubusercontent.com/102056/38819696-61520282-419c-11e8-8301-be5487384e9c.png)
