### PR TITLE
Fix truncated text in snapshot menu

### DIFF
--- a/boot/grub2/theme/theme.txt
+++ b/boot/grub2/theme/theme.txt
@@ -17,8 +17,8 @@ terminal-font: "Gnu Unifont Mono Regular 16"
 }
 
 + boot_menu {
-  left = 50%-200
-  width = 400
+  left = 10%
+  width = 80%
   top = 33%
   height = 34%	
 


### PR DESCRIPTION
The truncated text is mostly a result of available space not fully
utilized. To use as more space as possible, we extend boot menu width to
be 80% of the overall screen width.

This fixes bsc#1017558 - Cannot view timestamp of read-only snapshots in
GRUB as names truncated.