### PR TITLE
Prevent tiny installation font (bsc#1124508)

### DIFF
--- a/yast/installation.qss
+++ b/yast/installation.qss
@@ -7,6 +7,7 @@ YQDialog { background: #EEEEEE; color:#333;  }
 
 * {
   font-family:"Source Sans Pro",sans;
+  font: 10.5pt
 }
 
 #LogoHBox {

--- a/yast/installation.qss
+++ b/yast/installation.qss
@@ -164,7 +164,7 @@ QListWidget {
 #DialogHeadingLeft {
 
   font-family: "Open Sans Condensed", Sans-serif;
-  font: 25px;
+  font: 18pt;
   color: #333;
   qproperty-alignment:AlignLeft;
   font-weight:bold;
@@ -172,7 +172,7 @@ QListWidget {
 #DialogHeadingTop {
 
   font-family: "Open Sans Condensed", Sans-serif;
-  font: 25px;
+  font: 18pt;
   color: #333;
   font-weight:bold;
 }


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1124508

## Problem

Since the latest change to the "Source Sans Pro" font, the font in the YaST installer has become too tiny.

## Cause

That font appears to have slightly different font metrics to the prior default font, so the default size that Qt chooses if nothing is specified (10 pt as far as I can tell) does not fit anymore. The installation widget style sheet did not provide an explicit font size; it relied on whatever Qt chose as the default.

## Fix

Explicitly set a well-defined font size. Since this font appears to have different font metrics, 10.5 pt turned out to be a reasonable value.

## Screenshots

### Before (Tiny Font)

![06-before-proposal](https://user-images.githubusercontent.com/11538225/53424966-792f9900-39e4-11e9-8904-36584384aac2.png)

### Now (10.5 pt)

![16-10-5pt-proposal](https://user-images.githubusercontent.com/11538225/53424989-864c8800-39e4-11e9-80f8-c071b323020d.png)

### For Comparison: Leap 15.0

![leap-15-04-installation-settings](https://user-images.githubusercontent.com/11538225/53425039-96fcfe00-39e4-11e9-878e-39d8967f09d4.png)

## Complete Set of Screenshots

### Before

![00-before-license](https://user-images.githubusercontent.com/11538225/53425127-c875c980-39e4-11e9-928e-286245eaaabd.png)
![01-before-repos](https://user-images.githubusercontent.com/11538225/53425137-cd3a7d80-39e4-11e9-9087-4772ea3a580c.png)
![02-before-busy](https://user-images.githubusercontent.com/11538225/53425144-d0356e00-39e4-11e9-9e66-760fb74d2e47.png)
![03-before-system-role](https://user-images.githubusercontent.com/11538225/53425151-d3305e80-39e4-11e9-9f5a-61f34c69deaf.png)
![04-before-partitioning](https://user-images.githubusercontent.com/11538225/53425165-d7f51280-39e4-11e9-98a2-9e3e4f47b812.png)
![05-before-users](https://user-images.githubusercontent.com/11538225/53425172-da576c80-39e4-11e9-8871-844471603457.png)
![06-before-proposal](https://user-images.githubusercontent.com/11538225/53425185-dcb9c680-39e4-11e9-986e-7d849bb509c8.png)

### Now (10.5 pt)

![10-10-5pt-license](https://user-images.githubusercontent.com/11538225/53425220-ea6f4c00-39e4-11e9-9e58-d8e9d926992b.png)
![11-10-5pt-repos](https://user-images.githubusercontent.com/11538225/53425231-ed6a3c80-39e4-11e9-8d9a-4d7e2673afec.png)
![12-10-5pt-busy](https://user-images.githubusercontent.com/11538225/53425238-efcc9680-39e4-11e9-8a6d-cc7b37edc0c1.png)
![13-10-5pt-system-role](https://user-images.githubusercontent.com/11538225/53425246-f1965a00-39e4-11e9-9227-89d37e1eabcb.png)
![14-10-5pt-partitioning](https://user-images.githubusercontent.com/11538225/53425253-f3f8b400-39e4-11e9-964e-3d67adc0dfda.png)
![15-10-5pt-users](https://user-images.githubusercontent.com/11538225/53425255-f65b0e00-39e4-11e9-9e5a-e5691eef8972.png)
![16-10-5pt-proposal](https://user-images.githubusercontent.com/11538225/53425259-f824d180-39e4-11e9-98f1-8c9d5dcf41eb.png)

### For Comparison: Leap 15.0

![leap-15-00-license](https://user-images.githubusercontent.com/11538225/53425304-05da5700-39e5-11e9-99ff-9f4d4b222f42.png)
![leap-15-01-system-role](https://user-images.githubusercontent.com/11538225/53425309-083cb100-39e5-11e9-95eb-90bf8d736901.png)
![leap-15-02-suggested-partitioning](https://user-images.githubusercontent.com/11538225/53425314-0a067480-39e5-11e9-8e82-72162a567a93.png)
![leap-15-03-local-user](https://user-images.githubusercontent.com/11538225/53425321-0c68ce80-39e5-11e9-8c84-6865dd0d5d55.png)
![leap-15-04-installation-settings](https://user-images.githubusercontent.com/11538225/53425325-0ecb2880-39e5-11e9-9bb9-7683bd8dfb2d.png)
