### PR TITLE
plymouth will use plymouthd.defaults instead of plymouth.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,7 @@ install: # do not add requires here, this runs from generated SLE
 	perl -pi -e "s/THEME_NAME/${THEME}/" ${DESTDIR}/usr/share/grub2/themes/${THEME}/activate-theme
 
 	mkdir -p ${DESTDIR}/usr/share/plymouth/themes/${THEME}
+	cp -a plymouth/config/plymouthd.defaults ${DESTDIR}/usr/share/plymouth/
 	cp -a plymouth/theme/* ${DESTDIR}/usr/share/plymouth/themes/${THEME}
 
 #	install -d ${DESTDIR}/usr/share/kde4/apps/ksplash/Themes

--- a/plymouth/config/plymouthd.defaults
+++ b/plymouth/config/plymouthd.defaults
@@ -1,0 +1,4 @@
+[Daemon]
+Theme=bgrt
+ShowDelay=0
+DeviceTimeout=8


### PR DESCRIPTION
packge plymouthd.defaults in a seperet RPM. this can avoid change
SUSE or openSUSE branding section with is_opensuse macro in the
config file. means this modification can close the leaps gap
(jsc#SLE-11637).