### PR TITLE
Style disabled menu entries (bsc#1182668)

### DIFF
--- a/yast/cyan-black.qss
+++ b/yast/cyan-black.qss
@@ -219,7 +219,6 @@ QMenu::item:disabled {
 }
 QMenu::separator {
   background: rgba(0, 255, 255, 150);
-  height: 1px;
 }
 
 QGroupBox::title {

--- a/yast/cyan-black.qss
+++ b/yast/cyan-black.qss
@@ -214,6 +214,13 @@ QMenu {
   selection-background-color: cyan;
   selection-color: black;
 }
+QMenu::item:disabled {
+  color: rgba(0, 255, 255, 150);
+}
+QMenu::separator {
+  background: rgba(0, 255, 255, 150);
+  height: 1px;
+}
 
 QGroupBox::title {
   color: cyan;

--- a/yast/highcontrast.qss
+++ b/yast/highcontrast.qss
@@ -215,6 +215,11 @@ QMenu {
 
 QMenu::item:disabled { color: gray; }
 
+QMenu::separator {
+  background: gray;
+  height: 1px;
+}
+
 QGroupBox::title {
   color: cyan;
 }

--- a/yast/highcontrast.qss
+++ b/yast/highcontrast.qss
@@ -217,7 +217,6 @@ QMenu::item:disabled { color: gray; }
 
 QMenu::separator {
   background: gray;
-  height: 1px;
 }
 
 QGroupBox::title {

--- a/yast/installation.qss
+++ b/yast/installation.qss
@@ -367,6 +367,7 @@ QMenu {
   background: #fff;
   selection-background-color: #73ba25;
   selection-color: #fff;
+  border: 1px solid rgba(0, 0, 0, 60);
 }
 QMenu::item:disabled {
   color: rgba(0, 0, 0, 60);

--- a/yast/installation.qss
+++ b/yast/installation.qss
@@ -372,6 +372,9 @@ QMenu {
 QMenu::item:disabled {
   color: rgba(0, 0, 0, 60);
 }
+QMenu::separator {
+  height: 1px;
+}
 QGroupBox {
   border: 0px;
   margin-top: 2.5ex;

--- a/yast/installation.qss
+++ b/yast/installation.qss
@@ -368,6 +368,9 @@ QMenu {
   selection-background-color: #73ba25;
   selection-color: #fff;
 }
+QMenu::item:disabled {
+  color: rgba(0, 0, 0, 60);
+}
 QGroupBox {
   border: 0px;
   margin-top: 2.5ex;

--- a/yast/white-black.qss
+++ b/yast/white-black.qss
@@ -218,6 +218,13 @@ QMenu {
   selection-background-color: white;
   selection-color: black;
 }
+QMenu::item:disabled {
+  color: rgba(255, 255, 255, 150);
+}
+QMenu::separator {
+  background: rgba(255, 255, 255, 150);
+  height: 1px;
+}
 
 QGroupBox::title {
   color: white;

--- a/yast/white-black.qss
+++ b/yast/white-black.qss
@@ -223,7 +223,6 @@ QMenu::item:disabled {
 }
 QMenu::separator {
   background: rgba(255, 255, 255, 150);
-  height: 1px;
 }
 
 QGroupBox::title {


### PR DESCRIPTION
## Problem

* Enabled and disabled menu entries look identical, making impossible to distinguish them.
* The pull-down menu limits are not clear, which makes it to look _fusioned_ with other UI elements using the same background color.
* https://bugzilla.suse.com/show_bug.cgi?id=1182668

## Proposed solutions

* To _grayout_ disabled menu items, in a similar way it is [already done in SLE installation theme](https://github.com/yast/yast-theme/blob/66afaf358650b9e0f8bcc4deb6af2f063e4319e4/theme/SLE/wizard/installation.qss#L419)
* To use a border for the pull-down menu.

## Tests

Tested manually by using the [style sheet editor](https://en.opensuse.org/SDB:YaST_tricks#YaST_Hotkeys) (<kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>Alt</kbd> <kbd>S</kbd>).

## Screenshots

<details>
<summary>Click to show / hide some screenshots</summary>

---

| Stylesheet | Before | After |
|-|-|-|
| installation.qss | ![installation.qss before](https://user-images.githubusercontent.com/1691872/115430456-4cf6b800-a1fc-11eb-8557-09648f7055dc.png) | ![installation.qss after](https://user-images.githubusercontent.com/1691872/115430523-5849e380-a1fc-11eb-8d74-d22701a927c9.png) |
|cyan-black.qss | ![cyan-black.qss before](https://user-images.githubusercontent.com/1691872/115431123-de662a00-a1fc-11eb-9dce-331900a5d62c.png) | ![cyan-black.qss after](https://user-images.githubusercontent.com/1691872/115431170-e920bf00-a1fc-11eb-9f52-37c5b580f946.png) |
| white-black.qss | ![white-black.qss before](https://user-images.githubusercontent.com/1691872/115431233-fb026200-a1fc-11eb-88b5-886208442959.png) | ![white-black.qss after](https://user-images.githubusercontent.com/1691872/115431345-1a00f400-a1fd-11eb-87c7-ee99b8432fd2.png) |
| highcontrast.qss <p><sub>(only separator changes)</sub></p> | ![highcontrast.qss before](https://user-images.githubusercontent.com/1691872/115430667-7a436600-a1fc-11eb-9f9a-0101ce2b0d67.png) | ![highcontrast.qss after](https://user-images.githubusercontent.com/1691872/115430940-b37bd600-a1fc-11eb-94fe-d3977823797e.png) |




