### PR TITLE
Rename Source Sans Pro to Source Sans 3

### DIFF
--- a/yast/installation.qss
+++ b/yast/installation.qss
@@ -6,7 +6,7 @@ YQWizard { background: #EEEEEE;  }
 YQDialog { background: #EEEEEE; color:#333;  }
 
 * {
-  font-family:"Source Sans Pro",sans;
+  font-family:"Source Sans 3",sans;
   font-size: 10.5pt
 }
 
@@ -32,18 +32,18 @@ YQDialog { background: #EEEEEE; color:#333;  }
 }
 .current-step-name {
   color:#fff;
-  font-family:"Source Sans Pro Semibold",sans;
+  font-family:"Source Sans 3 Semibold",sans;
 }
 .done-step-name {
   color:#fff;
-  font-family:"Source Sans Pro Light",sans;
+  font-family:"Source Sans 3 Light",sans;
 }
 .todo-step-name {
   color:#fff;
-  font-family:"Source Sans Pro Light",sans;
+  font-family:"Source Sans 3 Light",sans;
 }
 .steps_heading {
-  font-family:"Source Sans Pro",sans;
+  font-family:"Source Sans 3",sans;
   color: #35b9ab;
   font-weight:bold;
 }

--- a/yast/style.qss
+++ b/yast/style.qss
@@ -8,18 +8,18 @@ color: #fff;
 }
 .current-step-name {
 color:#fff;
-  font-family:"Source Sans Pro Semibold",sans;
+  font-family:"Source Sans 3 Semibold",sans;
 }
 .done-step-name {
 color:#fff;
-font-family:"Source Sans Pro Light",sans;
+font-family:"Source Sans 3 Light",sans;
 }
 .todo-step-name {
 color:#fff;
-font-family:"Source Sans Pro Light",sans;
+font-family:"Source Sans 3 Light",sans;
 }
 .steps_heading {
-  font-family:"Source Sans Pro",sans;
+  font-family:"Source Sans 3",sans;
   color: #35b9ab;
   font-weight:bold;
 }


### PR DESCRIPTION
As stated in https://github.com/openSUSE/installation-images/pull/516, `adobe-sourcesanspro-fonts` changed font names from "Source Sans Pro" to "Source Sans 3". See https://github.com/adobe-fonts/source-sans/issues/192

So, now that [new version has arrived at Factory](https://build.opensuse.org/request/show/910248), let's update the .qss files to avoid problems.

Related to  

* https://bugzilla.suse.com/show_bug.cgi?id=1188927,  and
* https://bugzilla.suse.com/show_bug.cgi?id=1189267