### PR TITLE
[Tumbleweed] Make title QToolButton backgrounds transparent 

### DIFF
--- a/yast/installation.qss
+++ b/yast/installation.qss
@@ -13,6 +13,11 @@ YQDialog { background: #EEEEEE; color:#333;  }
 #LogoHBox {
   background-color: #173f4f;
 }
+
+#LogoHBox QToolButton {
+  background: transparent;
+}
+
 #DialogLogo {
   background-image: url(logo.svg);
   min-width: 180px;


### PR DESCRIPTION
## Problem

The unstyled QToolButton holding the theme switcher is not honoring the transparent background used by the PNG file.

## Solution

Set the `#LogoHBox QToolButton` background to transparent.

## Screenshots

| Before | After |
|-|-|
| ![theme_switcher_before](https://user-images.githubusercontent.com/1691872/155493361-a869f8ae-a633-43a3-8c4f-0fb11656a7c1.png) | ![theme_switcher_after](https://user-images.githubusercontent.com/1691872/155493399-db7790f4-d019-41c1-a661-f04e6167e318.png) |

## Related links

* https://github.com/yast/yast-theme/pull/156
* https://github.com/openSUSE/branding/pull/133
* https://github.com/libyui/libyui/pull/65
