### PR TITLE
Convert Plasma wallpaper metadata to JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ wallpaper.d:
 	rsvg-convert raw-theme-drop/desktop-1920x1200.svg -o tmp-$@.png
 	gm convert -quality 100 -interlace None -colorspace YCbCr -sampling-factor 2x2 tmp-$@.png openSUSE/wallpapers/openSUSEdefault/screenshot.jpg
 	rm tmp-$@.png
-	cp -p kde-workspace/metadata.desktop openSUSE/wallpapers/openSUSEdefault/metadata.desktop
+	cp -p kde-workspace/metadata.json openSUSE/wallpapers/openSUSEdefault/metadata.json
 
 wallpaper.d_clean:
 	rm -rf openSUSE/wallpapers

--- a/kde-workspace/metadata.desktop
+++ b/kde-workspace/metadata.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Name=openSUSE default
-
-X-KDE-PluginInfo-Name=Azul-openSUSE
-X-KDE-PluginInfo-Author=openSUSE Artwork Team
-X-KDE-PluginInfo-Email=opensuse-artwork@opensuse.org
-X-KDE-PluginInfo-License=GPLv2
-

--- a/kde-workspace/metadata.json
+++ b/kde-workspace/metadata.json
@@ -1,0 +1,13 @@
+{
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "opensuse-artwork@opensuse.org",
+                "Name": "openSUSE Artwork Team"
+            }
+        ],
+        "Id": "Azul-openSUSE",
+        "License": "GPLv2",
+        "Name": "openSUSE default"
+    }
+}


### PR DESCRIPTION
Plasma 6 drops support for metadata.desktop.