### PR TITLE
Sync further changes from TW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ wallpaper.d:
 	done
 	rsvg-convert raw-theme-drop/desktop-1920x1200.svg -o openSUSE/wallpapers/openSUSEdefault/screenshot.png
 	optipng -o5 openSUSE/wallpapers/openSUSEdefault/screenshot.png
-	cp -p kde-workspace/metadata.desktop openSUSE/wallpapers/openSUSEdefault/metadata.desktop
+	cp -p kde-workspace/metadata.json openSUSE/wallpapers/openSUSEdefault/metadata.json
 
 wallpaper.d_clean:
 	rm -rf openSUSE/wallpapers

--- a/Makefile
+++ b/Makefile
@@ -146,11 +146,6 @@ install:
 	# Libreoffice branding
 	mkdir -p $(DESTDIR)/usr/share/libreoffice
 	cp -r openSUSE/libreoffice/program $(DESTDIR)/usr/share/libreoffice
-	# osrelease icons
-	mkdir -p $(DESTDIR)/usr/share/icons/hicolor/scalable/emblems $(DESTDIR)/usr/share/icons/hicolor/symbolic/emblems
-	ln -sf /usr/share/pixmaps/distribution-logos/square-hicolor.svg ${DESTDIR}/usr/share/icons/hicolor/scalable/emblems/distributor-logo.svg
-	ln -sf /usr/share/pixmaps/distribution-logos/square-symbolic.svg $(DESTDIR)/usr/share/icons/hicolor/symbolic/emblems/distributor-logo-symbolic.svg
-	ln -sf /usr/share/pixmaps/distribution-logos/apple-touch-icon.png $(DESTDIR)/usr/share/icons/hicolor/symbolic/emblems/apple-touch-icon.png
 	# Brand file
 	cp -r SUSE-brand $(DESTDIR)/etc/
 

--- a/kde-workspace/metadata.desktop
+++ b/kde-workspace/metadata.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Name=openSUSE default
-
-X-KDE-PluginInfo-Name=Azul-openSUSE
-X-KDE-PluginInfo-Author=openSUSE Artwork Team
-X-KDE-PluginInfo-Email=opensuse-artwork@opensuse.org
-X-KDE-PluginInfo-License=GPLv2
-

--- a/kde-workspace/metadata.json
+++ b/kde-workspace/metadata.json
@@ -1,0 +1,13 @@
+{
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "opensuse-artwork@opensuse.org",
+                "Name": "openSUSE Artwork Team"
+            }
+        ],
+        "Id": "Azul-openSUSE",
+        "License": "GPLv2",
+        "Name": "openSUSE default"
+    }
+}


### PR DESCRIPTION
* Drop hicolor symlinks from Makefile which are no longer present in TW
   exactly these are raising unpackaged errors on Leap 16.0 build.

* Backport Fabian's change
   Plasma 6 drops support for metadata.desktop.as Leap 16.0 will have also Plasma 6+
